### PR TITLE
css_scraypuh

### DIFF
--- a/.ipynb_checkpoints/News_Scraping-checkpoint.ipynb
+++ b/.ipynb_checkpoints/News_Scraping-checkpoint.ipynb
@@ -16,11 +16,9 @@
     "* Axios\n",
     "* Functionality to add news article to SQL database after the fact\n",
     "* Auto open word doc in gen_docx\n",
-    "* Detroit News\n",
     "* Add Phys.org\n",
-    "* Transport Policy\n",
     "* [Journal of Modern Transportation](https://link.springer.com/journal/40534) -- add offline issues\n",
-    "* Journal of Urban Economics\n",
+    "* Add infinite scrolling functionality to css_scraypuh\n",
     "\n",
     "### Can't because of paywalls:\n",
     "* WSJ\n",
@@ -30,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-29T11:29:08.311107Z",
@@ -38,17 +36,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\EBarnard\\AppData\\Local\\Continuum\\anaconda3-1\\lib\\site-packages\\ipykernel\\parentpoller.py:116: UserWarning: Parent poll failed.  If the frontend dies,\n",
-      "                the kernel may be left running.  Please let us know\n",
-      "                about your system (bitness, Python, etc.) at\n",
-      "                ipython-dev@scipy.org\n",
-      "  ipython-dev@scipy.org\"\"\")\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -69,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-01-07T13:30:37.376863Z",
@@ -97,6 +84,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import sys\n",
     "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -119,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-01-07T13:30:37.453156Z",
@@ -171,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-01-07T13:30:37.503023Z",
@@ -427,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-01-07T13:30:37.531950Z",
@@ -583,7 +571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 29,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-01-07T13:30:37.588794Z",
@@ -883,6 +871,19 @@
     "                                     'sum_loc': \"[par for par in list(article.find('div', class_='post-content entry-content js_entry-content ').children) if str(par)[:3] =='<p>']\",\n",
     "                                     'title_loc': \"article.h1.text\",\n",
     "                                     'strain_bool': True},\n",
+    "                \n",
+    "                'Governing': {'url':  'http://www.governing.com/news/headlines',\n",
+    "                                     'source': 'Governing',\n",
+    "                                     'strain_tag': 'article',\n",
+    "                                     'strain_attr_name': 'class',\n",
+    "                                     'strain_attr_value': 'postlist__item--compact',\n",
+    "                                     'url_list_query': \"[article.a['href'] for article in self.base_soup.find_all('article', class_='postlist__item--compact')]\",\n",
+    "                                     'date_loc': \"article.time['datetime'].split('T')[0]\",\n",
+    "                                     'date_format': None,\n",
+    "                                     # The below method of searching for the summary filters out some odd divs in the middle of articles.\n",
+    "                                     'sum_loc': \"[par for par in list(article.find('div', class_='post-content entry-content js_entry-content ').children) if str(par)[:3] =='<p>']\",\n",
+    "                                     'title_loc': \"article.h1.text\",\n",
+    "                                     'strain_bool': True},\n",
     "                }"
    ]
   },
@@ -903,7 +904,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 30,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-01-07T13:37:17.149891Z",
@@ -915,10 +916,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "19 Jalopnik article(s) scraped\n",
-      "0 Jalopnik article(s) skipped due to error\n",
-      "1 Jalopnik article(s) skipped due to age\n",
-      "1 relevant article(s) collected\n"
+      "0 Governing article(s) scraped\n",
+      "0 Governing article(s) skipped due to error\n",
+      "0 Governing article(s) skipped due to age\n",
+      "0 relevant article(s) collected\n"
      ]
     }
    ],
@@ -927,7 +928,7 @@
     "scraypahs = {}\n",
     "temp_start_time = time.time()\n",
     "\n",
-    "name = 'Jalopnik'\n",
+    "name = 'Governing'\n",
     "scraypahs[name] = scraypah(scraper_dict[name])\n",
     "scraypahs[name].get_urls()\n",
     "scraypahs[name].scrape_em()\n",
@@ -939,7 +940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-01-07T13:36:05.340083Z",
@@ -952,7 +953,243 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "MIT\n"
+      "MIT\n",
+      "7 MIT article(s) scraped\n",
+      "0 MIT article(s) skipped due to error\n",
+      "25 MIT article(s) skipped due to age\n",
+      "0 relevant article(s) collected\n",
+      "\n",
+      "SemEng\n",
+      "'NoneType' object is not callable: https://semiengineering.com/inferencing-at-the-edge/ \n",
+      "date:2019-01-10\n",
+      "title:None\n",
+      "summary:[<p><span class=\"embed-youtube\" style=\"text-align:center; display: block;\"><iframe allowfullscreen=\"true\" class=\"youtube-player\" height=\"360\" src=\"https://www.youtube.com/embed/1BTxwew--5U?version=3&amp;rel=1&amp;fs=1&amp;autohide=2&amp;showsearch=0&amp;showinfo=1&amp;iv_load_policy=1&amp;wmode=transparent\" style=\"border:0;\" type=\"text/html\" width=\"640\"></iframe></span></p>]\n",
+      "4 Semiconductor Engineering article(s) scraped\n",
+      "1 Semiconductor Engineering article(s) skipped due to error\n",
+      "13 Semiconductor Engineering article(s) skipped due to age\n",
+      "2 relevant article(s) collected\n",
+      "\n",
+      "Quartz\n",
+      "'NoneType' object has no attribute 'text': https://qz.com/1495144/chinas-self-driving-efforts-need-to-accelerate/ \n",
+      "date:None\n",
+      "title:None\n",
+      "summary:None\n",
+      "0 Quartz article(s) scraped\n",
+      "1 Quartz article(s) skipped due to error\n",
+      "9 Quartz article(s) skipped due to age\n",
+      "0 relevant article(s) collected\n",
+      "\n",
+      "Recode\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\EBarnard\\AppData\\Local\\Continuum\\anaconda3-1\\lib\\site-packages\\dateutil\\parser\\_parser.py:1204: UnknownTimezoneWarning: tzname EST identified but not understood.  Pass `tzinfos` argument in order to correctly return a timezone-aware datetime.  In a future version, this will raise an exception.\n",
+      "  category=UnknownTimezoneWarning)\n",
+      "C:\\Users\\EBarnard\\AppData\\Local\\Continuum\\anaconda3-1\\lib\\site-packages\\dateutil\\parser\\_parser.py:1204: UnknownTimezoneWarning: tzname EDT identified but not understood.  Pass `tzinfos` argument in order to correctly return a timezone-aware datetime.  In a future version, this will raise an exception.\n",
+      "  category=UnknownTimezoneWarning)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "19 Recode article(s) scraped\n",
+      "0 Recode article(s) skipped due to error\n",
+      "16 Recode article(s) skipped due to age\n",
+      "2 relevant article(s) collected\n",
+      "\n",
+      "GovTech\n",
+      "7 GovTech article(s) scraped\n",
+      "0 GovTech article(s) skipped due to error\n",
+      "40 GovTech article(s) skipped due to age\n",
+      "2 relevant article(s) collected\n",
+      "\n",
+      "Reuters\n",
+      "61 Reuters article(s) scraped\n",
+      "0 Reuters article(s) skipped due to error\n",
+      "0 Reuters article(s) skipped due to age\n",
+      "3 relevant article(s) collected\n",
+      "\n",
+      "CityLab\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\EBarnard\\AppData\\Local\\Continuum\\anaconda3-1\\lib\\site-packages\\dateutil\\parser\\_parser.py:1204: UnknownTimezoneWarning: tzname ET identified but not understood.  Pass `tzinfos` argument in order to correctly return a timezone-aware datetime.  In a future version, this will raise an exception.\n",
+      "  category=UnknownTimezoneWarning)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "14 Citylab article(s) scraped\n",
+      "0 Citylab article(s) skipped due to error\n",
+      "7 Citylab article(s) skipped due to age\n",
+      "3 relevant article(s) collected\n",
+      "\n",
+      "Autoblog\n",
+      "HTTPSConnectionPool(host='www.autoblog.comhttps', port=443): Max retries exceeded with url: //www.autoblog.com/photos/top-10-classic-cars-on-the-rise/ (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x000000000B7D18D0>: Failed to establish a new connection: [WinError 10060] A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond')): https://www.autoblog.comhttps://www.autoblog.com/photos/top-10-classic-cars-on-the-rise/ \n",
+      "date:None\n",
+      "title:None\n",
+      "summary:None\n",
+      "'NoneType' object has no attribute 'text': https://www.autoblog.com/2019/01/10/2019-genesis-g70-review-comparison/ \n",
+      "date:2019-01-10\n",
+      "title:None\n",
+      "summary:None\n",
+      "HTTPSConnectionPool(host='www.autoblog.comhttps', port=443): Max retries exceeded with url: //www.autoblog.com/photos/best-new-car-deals/ (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x000000000C4BABE0>: Failed to establish a new connection: [WinError 10060] A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond')): https://www.autoblog.comhttps://www.autoblog.com/photos/best-new-car-deals/ \n",
+      "date:None\n",
+      "title:None\n",
+      "summary:None\n",
+      "HTTPSConnectionPool(host='www.autoblog.comhttps', port=443): Max retries exceeded with url: //www.autoblog.com/photos/best-selling-cars/ (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x000000000BF8DD30>: Failed to establish a new connection: [WinError 10060] A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond')): https://www.autoblog.comhttps://www.autoblog.com/photos/best-selling-cars/ \n",
+      "date:None\n",
+      "title:None\n",
+      "summary:None\n",
+      "'NoneType' object has no attribute 'text': https://www.autoblog.com/2019/01/09/2019-jaguar-i-pace-review-quick-spin/ \n",
+      "date:2019-01-09\n",
+      "title:None\n",
+      "summary:None\n",
+      "100 Autoblog article(s) scraped\n",
+      "5 Autoblog article(s) skipped due to error\n",
+      "0 Autoblog article(s) skipped due to age\n",
+      "5 relevant article(s) collected\n",
+      "\n",
+      "Electrek\n",
+      "44 Electrek article(s) scraped\n",
+      "0 Electrek article(s) skipped due to error\n",
+      "0 Electrek article(s) skipped due to age\n",
+      "6 relevant article(s) collected\n",
+      "\n",
+      "The Verge\n",
+      "'NoneType' object has no attribute 'text': https://www.theverge.com/2018/12/28/18152942/2018-tech-recap-facebook-google-microsoft-twitter-amazon \n",
+      "date:None\n",
+      "title:None\n",
+      "summary:None\n",
+      "25 The Verge article(s) scraped\n",
+      "1 The Verge article(s) skipped due to error\n",
+      "13 The Verge article(s) skipped due to age\n",
+      "9 relevant article(s) collected\n",
+      "\n",
+      "Crunchbase\n",
+      "('Unknown string format:', '5 hours ago'): https://news.crunchbase.com/news/drone-in-aisle-one-pensa-systems-raises-5m-series-a-to-make-retail-more-efficient/ \n",
+      "date:None\n",
+      "title:None\n",
+      "summary:None\n",
+      "('Unknown string format:', '4 hours ago'): https://news.crunchbase.com/news/how-the-government-shutdown-could-delay-unicorn-ipos/ \n",
+      "date:None\n",
+      "title:None\n",
+      "summary:None\n",
+      "11 Crunchbase article(s) scraped\n",
+      "2 Crunchbase article(s) skipped due to error\n",
+      "5 Crunchbase article(s) skipped due to age\n",
+      "2 relevant article(s) collected\n",
+      "\n",
+      "Truck News\n",
+      "21 Truck News article(s) scraped\n",
+      "0 Truck News article(s) skipped due to error\n",
+      "9 Truck News article(s) skipped due to age\n",
+      "1 relevant article(s) collected\n",
+      "\n",
+      "Trucks.com\n",
+      "5 Trucks.com article(s) scraped\n",
+      "0 Trucks.com article(s) skipped due to error\n",
+      "9 Trucks.com article(s) skipped due to age\n",
+      "1 relevant article(s) collected\n",
+      "\n",
+      "TechCrunch\n",
+      "('Unknown string format:', 'video-arti'): https://techcrunch.com/video-article/google-built-an-entire-theme-park-ride-in-the-ces-parking-lot-because-they-can/ \n",
+      "date:None\n",
+      "title:None\n",
+      "summary:None\n",
+      "78 TechCrunch article(s) scraped\n",
+      "1 TechCrunch article(s) skipped due to error\n",
+      "0 TechCrunch article(s) skipped due to age\n",
+      "7 relevant article(s) collected\n",
+      "\n",
+      "Charged EVs\n",
+      "'NoneType' object is not callable: https://chargedevs.com/newswire/zf-friedrichshafen-to-invest-e800-million-in-hybrid-transmission-technology/ \n",
+      "date:2019-01-11\n",
+      "title:None\n",
+      "summary:[<p>ZF Friedrichshafen, a German-based automotive driveline and chassis manufacturer, is set to invest â‚¬800 million in the electrification of its transmission technology. Over the next four years, ZF will put the investment into its primary transmission plant located in SaarbrÃ¼cken, Germany.</p>, <p>â€œThe share of hybrid drives in production will increase tenfold over the next few years –</p>]\n",
+      "12 Charged EVs article(s) scraped\n",
+      "1 Charged EVs article(s) skipped due to error\n",
+      "7 Charged EVs article(s) skipped due to age\n",
+      "3 relevant article(s) collected\n",
+      "\n",
+      "ARS Technica\n",
+      "7 ARS Technica article(s) scraped\n",
+      "0 ARS Technica article(s) skipped due to error\n",
+      "23 ARS Technica article(s) skipped due to age\n",
+      "3 relevant article(s) collected\n",
+      "\n",
+      "Venture Beat\n",
+      "20 Venture Beat article(s) scraped\n",
+      "0 Venture Beat article(s) skipped due to error\n",
+      "20 Venture Beat article(s) skipped due to age\n",
+      "13 relevant article(s) collected\n",
+      "\n",
+      "IEEE Spectrum\n",
+      "1 IEEE Spectrum article(s) scraped\n",
+      "0 IEEE Spectrum article(s) skipped due to error\n",
+      "18 IEEE Spectrum article(s) skipped due to age\n",
+      "0 relevant article(s) collected\n",
+      "\n",
+      "Transport Topics\n",
+      "67 Transport Topics article(s) scraped\n",
+      "0 Transport Topics article(s) skipped due to error\n",
+      "30 Transport Topics article(s) skipped due to age\n",
+      "9 relevant article(s) collected\n",
+      "\n",
+      "GreenCarCongress\n",
+      "51 GreenCarCongress article(s) scraped\n",
+      "0 GreenCarCongress article(s) skipped due to error\n",
+      "29 GreenCarCongress article(s) skipped due to age\n",
+      "16 relevant article(s) collected\n",
+      "\n",
+      "Green Car Reports\n",
+      "20 Green Car Reports article(s) scraped\n",
+      "0 Green Car Reports article(s) skipped due to error\n",
+      "0 Green Car Reports article(s) skipped due to age\n",
+      "1 relevant article(s) collected\n",
+      "\n",
+      "The Fuse\n",
+      "0: http://energyfuse.org/this-week-in-avs-self-driving-grocery-deliveries-pave-coalition-formed-for-av-education-and-more/ \n",
+      "date:2019-01-11\n",
+      "title:None\n",
+      "summary:<p><strong><span style=\"text-decoration: underline;\">Cruise and DoorDash are going to start using self-driving cars to deliver groceries and takeout</span></strong></p>\n",
+      "0 The Fuse article(s) scraped\n",
+      "1 The Fuse article(s) skipped due to error\n",
+      "5 The Fuse article(s) skipped due to age\n",
+      "0 relevant article(s) collected\n",
+      "\n",
+      "Business Wire\n",
+      "24 Business Wire article(s) scraped\n",
+      "0 Business Wire article(s) skipped due to error\n",
+      "0 Business Wire article(s) skipped due to age\n",
+      "0 relevant article(s) collected\n",
+      "\n",
+      "U.S. Department of Energy\n",
+      "4 U.S. Department of Energy article(s) scraped\n",
+      "0 U.S. Department of Energy article(s) skipped due to error\n",
+      "21 U.S. Department of Energy article(s) skipped due to age\n",
+      "0 relevant article(s) collected\n",
+      "\n",
+      "jmtonline\n",
+      "0 Journal of Modern Transportation article(s) scraped\n",
+      "0 Journal of Modern Transportation article(s) skipped due to error\n",
+      "7 Journal of Modern Transportation article(s) skipped due to age\n",
+      "0 relevant article(s) collected\n",
+      "\n",
+      "Jalopnik\n",
+      "19 Jalopnik article(s) scraped\n",
+      "0 Jalopnik article(s) skipped due to error\n",
+      "1 Jalopnik article(s) skipped due to age\n",
+      "1 relevant article(s) collected\n"
      ]
     }
    ],
@@ -982,14 +1219,381 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-11-09T14:34:17.790747Z",
      "start_time": "2018-11-09T14:34:17.279486Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>index</th>\n",
+       "      <th>Errors</th>\n",
+       "      <th>Pages Scraped</th>\n",
+       "      <th>Relevant Articles</th>\n",
+       "      <th>Time spent</th>\n",
+       "      <th>Too old</th>\n",
+       "      <th>Time per relevant article</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>MIT</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>40.11</td>\n",
+       "      <td>25.0</td>\n",
+       "      <td>inf</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Semiconductor Engineering</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>35.44</td>\n",
+       "      <td>13.0</td>\n",
+       "      <td>17.720000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Quartz</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>6.73</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>inf</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Recode</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>19.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>26.21</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>13.105000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>GovTech</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>28.70</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>14.350000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Reuters</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>61.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>40.44</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>13.480000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>Citylab</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>14.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>13.54</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>4.513333</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>Autoblog</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>100.0</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>133.46</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>26.692000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>Electrek</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>44.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>29.22</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4.870000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>The Verge</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>25.0</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>24.63</td>\n",
+       "      <td>13.0</td>\n",
+       "      <td>2.736667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>Crunchbase</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>11.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>11.55</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>5.775000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>Truck News</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>21.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>29.08</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>29.080000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>Trucks.com</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>19.50</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>19.500000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>TechCrunch</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>78.0</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>35.84</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>5.120000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>Charged EVs</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>12.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>43.05</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>14.350000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>ARS Technica</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>25.98</td>\n",
+       "      <td>23.0</td>\n",
+       "      <td>8.660000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>Venture Beat</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>13.0</td>\n",
+       "      <td>20.24</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>1.556923</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>IEEE Spectrum</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>31.33</td>\n",
+       "      <td>18.0</td>\n",
+       "      <td>inf</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>Transport Topics</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>67.0</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>67.11</td>\n",
+       "      <td>30.0</td>\n",
+       "      <td>7.456667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>GreenCarCongress</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>51.0</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>155.90</td>\n",
+       "      <td>29.0</td>\n",
+       "      <td>9.743750</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>Green Car Reports</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>10.73</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>10.730000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>The Fuse</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>5.24</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>inf</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>Business Wire</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>24.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>11.94</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>inf</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>U.S. Department of Energy</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>37.05</td>\n",
+       "      <td>21.0</td>\n",
+       "      <td>inf</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>Journal of Modern Transportation</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>7.46</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>inf</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25</th>\n",
+       "      <td>Jalopnik</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>19.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>16.54</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>16.540000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                               index  Errors  Pages Scraped  \\\n",
+       "0                                MIT     0.0            7.0   \n",
+       "1          Semiconductor Engineering     1.0            4.0   \n",
+       "2                             Quartz     1.0            0.0   \n",
+       "3                             Recode     0.0           19.0   \n",
+       "4                            GovTech     0.0            7.0   \n",
+       "5                            Reuters     0.0           61.0   \n",
+       "6                            Citylab     0.0           14.0   \n",
+       "7                           Autoblog     5.0          100.0   \n",
+       "8                           Electrek     0.0           44.0   \n",
+       "9                          The Verge     1.0           25.0   \n",
+       "10                        Crunchbase     2.0           11.0   \n",
+       "11                        Truck News     0.0           21.0   \n",
+       "12                        Trucks.com     0.0            5.0   \n",
+       "13                        TechCrunch     1.0           78.0   \n",
+       "14                       Charged EVs     1.0           12.0   \n",
+       "15                      ARS Technica     0.0            7.0   \n",
+       "16                      Venture Beat     0.0           20.0   \n",
+       "17                     IEEE Spectrum     0.0            1.0   \n",
+       "18                  Transport Topics     0.0           67.0   \n",
+       "19                  GreenCarCongress     0.0           51.0   \n",
+       "20                 Green Car Reports     0.0           20.0   \n",
+       "21                          The Fuse     1.0            0.0   \n",
+       "22                     Business Wire     0.0           24.0   \n",
+       "23         U.S. Department of Energy     0.0            4.0   \n",
+       "24  Journal of Modern Transportation     0.0            0.0   \n",
+       "25                          Jalopnik     0.0           19.0   \n",
+       "\n",
+       "    Relevant Articles  Time spent  Too old  Time per relevant article  \n",
+       "0                 0.0       40.11     25.0                        inf  \n",
+       "1                 2.0       35.44     13.0                  17.720000  \n",
+       "2                 0.0        6.73      9.0                        inf  \n",
+       "3                 2.0       26.21     16.0                  13.105000  \n",
+       "4                 2.0       28.70     40.0                  14.350000  \n",
+       "5                 3.0       40.44      0.0                  13.480000  \n",
+       "6                 3.0       13.54      7.0                   4.513333  \n",
+       "7                 5.0      133.46      0.0                  26.692000  \n",
+       "8                 6.0       29.22      0.0                   4.870000  \n",
+       "9                 9.0       24.63     13.0                   2.736667  \n",
+       "10                2.0       11.55      5.0                   5.775000  \n",
+       "11                1.0       29.08      9.0                  29.080000  \n",
+       "12                1.0       19.50      9.0                  19.500000  \n",
+       "13                7.0       35.84      0.0                   5.120000  \n",
+       "14                3.0       43.05      7.0                  14.350000  \n",
+       "15                3.0       25.98     23.0                   8.660000  \n",
+       "16               13.0       20.24     20.0                   1.556923  \n",
+       "17                0.0       31.33     18.0                        inf  \n",
+       "18                9.0       67.11     30.0                   7.456667  \n",
+       "19               16.0      155.90     29.0                   9.743750  \n",
+       "20                1.0       10.73      0.0                  10.730000  \n",
+       "21                0.0        5.24      5.0                        inf  \n",
+       "22                0.0       11.94      0.0                        inf  \n",
+       "23                0.0       37.05     21.0                        inf  \n",
+       "24                0.0        7.46      7.0                        inf  \n",
+       "25                1.0       16.54      1.0                  16.540000  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Smart Mobility articles found: 89\n",
+      "Alternative Fuel Vehicle articles found: 0\n",
+      "21CTP articles found: 0\n",
+      "Hyperloop articles found: 1\n"
+     ]
+    }
+   ],
    "source": [
     "# Meta-data from the scrape session\n",
     "scrape_specs_df = pd.DataFrame.from_dict(scrape_specs).T.reset_index()\n",
@@ -1043,14 +1647,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-10-17T16:55:54.374736Z",
      "start_time": "2018-10-17T16:55:54.098473Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Monday!\n",
+      "Some hyperloop stuff!\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<win32com.gen_py.None.Workbook>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Press enter to close Excel:  \n"
+     ]
+    }
+   ],
    "source": [
     "if (dt.date.today().weekday() == scraper_sched['CAV']):\n",
     "    print('Monday!')\n",
@@ -1094,14 +1724,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-10-17T17:25:20.873985Z",
      "start_time": "2018-10-17T17:25:20.757295Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CAV\n"
+     ]
+    }
+   ],
    "source": [
     "if dt.date.today().weekday() == scraper_sched['AFV']:\n",
     "    print('AFV')\n",
@@ -1124,7 +1762,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-09-12T11:30:00.039138Z",
@@ -1140,14 +1778,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-11-19T21:47:24.974039Z",
      "start_time": "2018-11-19T21:47:24.165717Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CAV\n"
+     ]
+    }
+   ],
    "source": [
     "conn = sqlite3.connect('news_updates.db')\n",
     "if (dt.date.today().weekday() == scraper_sched['CAV']) & (~db_update):\n",
@@ -1181,22 +1827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2018-12-19T15:07:50.946393Z",
-     "start_time": "2018-12-19T15:07:46.700321Z"
-    },
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "driver = webdriver.Chrome()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-12-19T15:07:50.976312Z",
@@ -1205,74 +1836,96 @@
    },
    "outputs": [],
    "source": [
-    "def paypuh_scraypuh(url, source):\n",
+    "def css_scraypuh(selenium_dict_value):\n",
     "    '''\n",
     "    bad_egg: Missing a key component (usually abstract), so skip printout/tracking\n",
     "    still_more: Date is still within past week, continue scraping!\n",
     "    '''\n",
-    "    soup = grab_homepage(url)\n",
-    "    papers_to_scrape = [paper.a['href'] for paper in soup.find_all(\n",
-    "        'div', attrs={'class': 'pod-listing-header'})]\n",
-    "    still_more = True\n",
+    "    max_age = 7 # take this out\n",
     "    scraped_count = 0\n",
     "    papers = {}\n",
-    "\n",
-    "    for paper in papers_to_scrape:\n",
-    "        #bad_egg bool becomes True if publication date of article can't be accessed.\n",
-    "        bad_egg = False \n",
-    "        if not still_more:\n",
-    "            break\n",
-    "        # Open article URL using selenium.\n",
-    "        driver.get(paper)\n",
-    "        # Get article publication date, title, and summary.\n",
-    "        try:\n",
-    "            driver.find_element_by_css_selector(\n",
-    "                \"span[class='CollapseText']\").click()\n",
-    "            date = pd.to_datetime(driver.find_element_by_css_selector(\n",
-    "                \"dl[class='articleDates smh']\").text.split('Available online ')[1]).date()\n",
+    "    \n",
+    "    # Important -- otherwise variables could be referenced before assignment.\n",
+    "    title = ''\n",
+    "    date = ''\n",
+    "    summary = ''\n",
+    "    \n",
+    "    if type(selenium_dict_value['url']) != list:\n",
+    "        selenium_dict_value['url'] = [selenium_dict_value['url']]\n",
+    "    for url in selenium_dict_value['url']:\n",
+    "        load_count = 0\n",
+    "        still_more = True\n",
+    "    \n",
+    "        driver.get(url)\n",
+    "        soup = BeautifulSoup(driver.page_source, \"html5lib\")\n",
+    "    \n",
+    "        # Click on CSS element to load more articles if available.\n",
+    "        if selenium_dict_value['load_more_css'] != None:\n",
+    "            for loadNo in range(selenium_dict_value['max_loads']):\n",
+    "                driver.find_element_by_css_selector(selenium_dict_value['load_more_css']).click()\n",
     "            soup = BeautifulSoup(driver.page_source, \"html5lib\")\n",
-    "            if (date - dt.date.today()).days > -max_age:\n",
-    "                title = soup.find('h1', class_='svTitle').text\n",
-    "                summary = soup.find(\n",
-    "                    'div', class_='abstract svAbstract ').p.text\n",
-    "            # If article is too old, set still_more = False.  This will break out of the for loop so that\n",
-    "            # paypuh_scraypuh() stops scraping papers from this source.\n",
-    "            else:\n",
-    "                still_more = False\n",
-    "        except:\n",
+    "        papers_to_scrape = eval(selenium_dict_value['url_list_query'])\n",
+    "        \n",
+    "        for paper in papers_to_scrape:\n",
+    "            bad_egg = False\n",
+    "            if not still_more or scraped_count > selenium_dict_value['max_scrapes']:\n",
+    "                break\n",
+    "            # Open article URL using selenium.\n",
+    "            driver.get(paper)\n",
+    "            soup = BeautifulSoup(driver.page_source, \"html5lib\")\n",
+    "            # Get article publication date, title, and summary.\n",
     "            try:\n",
-    "                # Use selenium to \"click\" the \"Show more\" button to reveal the date.\n",
-    "                driver.find_element_by_css_selector(\n",
-    "                    \"button[class='show-hide-details']\").click()\n",
-    "                soup = BeautifulSoup(driver.page_source, \"html5lib\")\n",
-    "                date = pd.to_datetime(soup.find('div', class_='wrapper').p.text.split(\n",
-    "                    'Available online ')[1]).date()\n",
-    "                # If age of article is less than max_age, get the article title and summary.\n",
-    "                if (date - dt.date.today()).days > -max_age:\n",
-    "                    title = soup.find('span', class_='title-text').text\n",
-    "                    summary = soup.find('div', class_='abstract author').p.text\n",
+    "                # Click on CSS element to reveal the location of the publication date if needed.\n",
+    "                if selenium_dict_value['date_css'] != None:\n",
+    "                    driver.find_element_by_css_selector(selenium_dict_value['date_css']).click()\n",
+    "                    soup = BeautifulSoup(driver.page_source, \"html5lib\")\n",
+    "                # Scrape the publication date.\n",
+    "                date = eval(selenium_dict_value['date_loc'])\n",
+    "                date = dt.datetime.strptime(date, selenium_dict_value['date_format']).date()\n",
+    "                # If the publication date shows the article is more recent than than max_age (in days) OR if articles are not \n",
+    "                # ordered by date (as in the case of Detroit News) scrape the title and summary.\n",
+    "                too_old = ((date - dt.date.today()).days <= -max_age)\n",
+    "                if not too_old:\n",
+    "                    # Click on CSS element to reveal the location of the title if needed.\n",
+    "                    if selenium_dict_value['title_css'] != None:\n",
+    "                        driver.find_element_by_css_selector(selenium_dict_value['title_css']).click()\n",
+    "                        soup = BeautifulSoup(driver.page_source, \"html5lib\")\n",
+    "                    # Scrape and clean the title.\n",
+    "                    title = eval(selenium_dict_value['title_loc'])\n",
+    "                    title = replace_em(title)\n",
+    "                    # Click on CSS element to reveal the location of the summary if needed.\n",
+    "                    if selenium_dict_value['sum_css'] != None:\n",
+    "                        driver.find_element_by_css_selector(selenium_dict_value['sum_css']).click()\n",
+    "                        soup = BeautifulSoup(driver.page_source, \"html5lib\")\n",
+    "                    # Scrape and clean the summary.\n",
+    "                    summary = eval(selenium_dict_value['sum_loc'])\n",
+    "                    summary = ' '.join([replace_em(p.text) for p in summary]) # Assumes that the summary is a list of paragraphs.\n",
+    "                    scraped_count += 1 \n",
+    "                    papers[scraped_count] = {\n",
+    "                            'title': title, 'summary': summary, 'link': paper, \n",
+    "                            'source': selenium_dict_value['source'], 'date': date}\n",
+    "                    \n",
+    "                # If article is too old, set still_more = False (if articles are ordered by date).  \n",
+    "                # This will break out of the for loop so that paypuh_scraypuh() stops scraping papers from this source.\n",
     "                else:\n",
-    "                    still_more = False\n",
-    "            # If publication date can't be accessed, skip article.\n",
-    "            except:\n",
+    "                    if selenium_dict_value['ordered_bool']:\n",
+    "                        still_more = False\n",
+    "            \n",
+    "            except Exception as e:\n",
     "                bad_egg = True\n",
-    "                print('bad egg in {}: {}'.format(source, paper))\n",
+    "                #print('bad egg in {}: {}'.format(selenium_dict_value['source'], paper))\n",
+    "                # Print out exception info.\n",
+    "                #print('Exception info: ', sys.exc_info(), '\\n')\n",
     "                pass\n",
-    "        scraped_count += 1\n",
-    "\n",
-    "        if still_more and not bad_egg:\n",
-    "            papers[scraped_count] = {\n",
-    "                'title': title, 'summary': summary, 'link': paper, 'source': source, 'date': date}\n",
-    "\n",
+    "            \n",
     "    # Print the number of papers scraped from each source.\n",
-    "    print('{} new papers in {}'.format(scraped_count, source))\n",
-    "    print(papers)\n",
+    "    print('{} new papers in {}'.format(scraped_count, selenium_dict_value['source']))\n",
     "    return pd.DataFrame(papers).T"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-12-19T15:08:24.521491Z",
@@ -1281,42 +1934,888 @@
    },
    "outputs": [],
    "source": [
-    "tparta = paypuh_scraypuh(\n",
-    "    'https://www.journals.elsevier.com/transportation-research-part-a-policy-and-practice/recent-articles', 'Transportation Part A')\n",
-    "tpartb = paypuh_scraypuh(\n",
-    "    'https://www.journals.elsevier.com/transportation-research-part-b-methodological/recent-articles', 'Transportation Part B')\n",
-    "tpartc = paypuh_scraypuh(\n",
-    "    'https://www.journals.elsevier.com/transportation-research-part-c-emerging-technologies/recent-articles', 'Transportation Part C')\n",
-    "tpartd = paypuh_scraypuh(\n",
-    "    'https://www.journals.elsevier.com/transportation-research-part-d-transport-and-environment/recent-articles', 'Transportation Part D')\n",
-    "tparte = paypuh_scraypuh(\n",
-    "    'https://www.journals.elsevier.com/transportation-research-part-e-logistics-and-transportation-review/recent-articles', 'Transportation Part E')\n",
-    "tpartf = paypuh_scraypuh(\n",
-    "    'https://www.journals.elsevier.com/transportation-research-part-f-traffic-psychology-and-behaviour/recent-articles', 'Transportation Part F')\n",
-    "\n",
-    "# Journal of Urban Economics -- not working correctly yet due to date format\n",
-    "joee = paypuh_scraypuh('https://www.journals.elsevier.com/journal-of-urban-economics/recent-articles', 'Journal of Urban Economics')"
+    "# sum_loc must provide directions for finding a list of paragraphs (not just paragraph text).\n",
+    "selenium_dict = {\n",
+    "                    'Detroit News': {'url': 'https://www.detroitnews.com/autos/',\n",
+    "                                     'source': 'Detroit News',\n",
+    "                                     'url_list_query': \"['https://www.detroitnews.com' + a['href'] for a in soup.find('div', class_='headline-page active').find_all('a')]\",\n",
+    "                                     'load_more_css': \"a.button-add-content\",\n",
+    "                                     'max_scrapes': 30,\n",
+    "                                     'max_loads': 2, # Make sure that loads is not too many -- otherwise load button may become inactive.  Test this.\n",
+    "                                     'ordered_bool': False,\n",
+    "                                     'date_css': None,\n",
+    "                                     'date_loc': \"soup.find('span', class_='asset-metabar-time asset-metabar-item nobyline').text.split('ET ')[1].split(' |')[0]\",\n",
+    "                                     'date_format': '%b. %d, %Y',\n",
+    "                                     'sum_css': None,\n",
+    "                                     'sum_loc': \"[soup.find('p', class_='speakable-p-1 p-text'), soup.find('p', class_='speakable-p-2 p-text')]\",\n",
+    "                                     'title_loc': \"soup.find('h1', class_='asset-headline speakable-headline').text\",\n",
+    "                                     'title_css': None},\n",
+    "                                 \n",
+    "                        'Transportation Research': {'url': ['https://www.journals.elsevier.com/transportation-research-part-a-policy-and-practice/recent-articles',\n",
+    "                                                            'https://www.journals.elsevier.com/transportation-research-part-b-methodological/recent-articles',\n",
+    "                                                            'https://www.journals.elsevier.com/transportation-research-part-c-emerging-technologies/recent-articles',\n",
+    "                                                            'https://www.journals.elsevier.com/transportation-research-part-d-transport-and-environment/recent-articles',\n",
+    "                                                            'https://www.journals.elsevier.com/transportation-research-part-e-logistics-and-transportation-review/recent-articles',\n",
+    "                                                            'https://www.journals.elsevier.com/transportation-research-part-f-traffic-psychology-and-behaviour/recent-articles' \n",
+    "                                                           ],\n",
+    "                                     'source': 'Transportation Research',\n",
+    "                                     'url_list_query': \"[div.a['href'] for div in soup.find_all('div', class_='pod-listing-header')]\",\n",
+    "                                     'load_more_css': None,\n",
+    "                                     'max_scrapes': 100,\n",
+    "                                     'max_loads': None,\n",
+    "                                     'ordered_bool': True,\n",
+    "                                     'date_css': \"button.show-hide-details\",\n",
+    "                                     'date_loc': \"soup.find('div', 'wrapper').p.text.split('online ')[1][:-1]\",\n",
+    "                                     'date_format': '%d %B %Y',\n",
+    "                                     'sum_css': None,\n",
+    "                                     'sum_loc': \"soup.find('div', class_='Abstracts').find_all('p', limit = 3)\",\n",
+    "                                     'title_loc': \"soup.h1.text\",\n",
+    "                                     'title_css': None},\n",
+    "    \n",
+    "                            'Journal of Urban Economics': {'url': 'https://www.journals.elsevier.com/journal-of-urban-economics/recent-articles',\n",
+    "                                     'source': 'Journal of Urban Economics',\n",
+    "                                     'url_list_query': \"[div.a['href'] for div in soup.find_all('div', class_='pod-listing-header')]\",\n",
+    "                                     'load_more_css': None,\n",
+    "                                     'max_scrapes': 100,\n",
+    "                                     'max_loads': None,\n",
+    "                                     'ordered_bool': True,\n",
+    "                                     'date_css': \"button.show-hide-details\",\n",
+    "                                     'date_loc': \"soup.find('div', 'wrapper').p.text.split('online ')[1][:-1]\",\n",
+    "                                     'date_format': '%d %B %Y',\n",
+    "                                     'sum_css': None,\n",
+    "                                     'sum_loc': \"soup.find('div', class_='Abstracts').find_all('p', limit = 3)\",\n",
+    "                                     'title_loc': \"soup.h1.text\",\n",
+    "                                     'title_css': None},\n",
+    "    \n",
+    "                            'Transport Policy': {'url': 'https://www.journals.elsevier.com/transport-policy/recent-articles',\n",
+    "                                     'source': 'Transport Policy',\n",
+    "                                     'url_list_query': \"[div.a['href'] for div in soup.find_all('div', class_='pod-listing-header')]\",\n",
+    "                                     'load_more_css': None,\n",
+    "                                     'max_scrapes': 100,\n",
+    "                                     'max_loads': None,\n",
+    "                                     'ordered_bool': True,\n",
+    "                                     'date_css': \"button.show-hide-details\",\n",
+    "                                     'date_loc': \"soup.find('div', 'wrapper').p.text.split('online ')[1][:-1]\",\n",
+    "                                     'date_format': '%d %B %Y',\n",
+    "                                     'sum_css': None,\n",
+    "                                     'sum_loc': \"soup.find('div', class_='Abstracts').find_all('p', limit = 3)\",\n",
+    "                                     'title_loc': \"soup.h1.text\",\n",
+    "                                     'title_css': None}\n",
+    "                                     }"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2018-12-19T15:08:24.871548Z",
-     "start_time": "2018-12-19T15:08:24.861576Z"
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://www.journals.elsevier.com/transportation-research-part-a-policy-and-practice/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-b-methodological/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-c-emerging-technologies/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-d-transport-and-environment/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-e-logistics-and-transportation-review/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-f-traffic-psychology-and-behaviour/recent-articles\n",
+      "24 new papers in Transportation Research\n"
+     ]
     }
-   },
-   "outputs": [],
+   ],
    "source": [
-    "week_o_papers = pd.concat([tparta, tpartb, tpartc, tpartd, tparte, tpartf, joee])\n",
-    "# week_o_papers.to_excel('{} papers.xls'.format(search_date))\n",
+    "driver = webdriver.Chrome()\n",
+    "df = css_scraypuh(selenium_dict['Transportation Research'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>link</th>\n",
+       "      <th>source</th>\n",
+       "      <th>summary</th>\n",
+       "      <th>title</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A novel traffic management strategy in automa...</td>\n",
+       "      <td>Driving aggressiveness management policy to en...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Areas of interventions for shared modes (Scho...</td>\n",
+       "      <td>Identifying areas of interventions for improve...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>This paper examines the transportation-growth ...</td>\n",
+       "      <td>The Transportation-growth nexus in USA: Fresh ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2019-01-12</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Activity-based models appeared as an answer to...</td>\n",
+       "      <td>Mobile phone records to feed activity-based tr...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>2019-01-12</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>With the recent advances in battery technology...</td>\n",
+       "      <td>Optimizing the deployment of electric vehicle ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Reliable shortest problem with link travel ti...</td>\n",
+       "      <td>An algorithm for reliable shortest path proble...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Reference models are dedicated to non-ordered...</td>\n",
+       "      <td>A new family of qualitative choice models: An ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A queueing theory-based model for matching ta...</td>\n",
+       "      <td>A Markov decision process approach to vacant t...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>2019-01-14</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>We propose a link-based cyclic tradable credi...</td>\n",
+       "      <td>Promoting social equity with cyclic tradable c...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>2019-01-12</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>This paper addresses one of the most challengi...</td>\n",
+       "      <td>Fair cost allocation for ridesharing services ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Mode and destination type choice were found t...</td>\n",
+       "      <td>Modeling household-level hurricane evacuation ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Image processing algorithm developed for accu...</td>\n",
+       "      <td>Tracking vehicle trajectories and fuel rates i...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A MIP model is built to improve the OD access...</td>\n",
+       "      <td>Timetable synchronization of last trains for u...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>CAVs are capable of learning the optimal cont...</td>\n",
+       "      <td>Deep reinforcement learning enabled self-learn...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A mixed integer linear model is developed to ...</td>\n",
+       "      <td>Coordinated optimization of tram trajectories ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Vehicle platoon is a set of vehicles driving ...</td>\n",
+       "      <td>Behaviorally stable vehicle platooning for ene...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>The relationship between commuting behaviour ...</td>\n",
+       "      <td>Commuting behavior and congestion satisfaction...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Health impact assessment of long-range transp...</td>\n",
+       "      <td>Modeling health equity in active transportatio...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>We monitored PM levels pre and post odd-even ...</td>\n",
+       "      <td>The effect of odd-even driving scheme on PM2.5...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Interest in foldable ocean containers to addr...</td>\n",
+       "      <td>The impact of foldable ocean containers on bac...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>This study investigates the purchase intentio...</td>\n",
+       "      <td>Effect of environmental awareness on purchase ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Driving is a combination of top-down and bott...</td>\n",
+       "      <td>Quantifying the difference between intention a...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Distraction caused by a music player and phon...</td>\n",
+       "      <td>Driver behaviour at the onset of yellow signal...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Drivers’ toll lane choices and their travel t...</td>\n",
+       "      <td>The effect of information on drivers’ toll lan...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          date                                               link  \\\n",
+       "1   2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "2   2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "3   2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "4   2019-01-12  https://www.sciencedirect.com/science/article/...   \n",
+       "5   2019-01-12  https://www.sciencedirect.com/science/article/...   \n",
+       "6   2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "7   2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "8   2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "9   2019-01-14  https://www.sciencedirect.com/science/article/...   \n",
+       "10  2019-01-12  https://www.sciencedirect.com/science/article/...   \n",
+       "11  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "12  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "13  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "14  2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "15  2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "16  2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "17  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "18  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "19  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "20  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "21  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "22  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "23  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "24  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "\n",
+       "                     source  \\\n",
+       "1   Transportation Research   \n",
+       "2   Transportation Research   \n",
+       "3   Transportation Research   \n",
+       "4   Transportation Research   \n",
+       "5   Transportation Research   \n",
+       "6   Transportation Research   \n",
+       "7   Transportation Research   \n",
+       "8   Transportation Research   \n",
+       "9   Transportation Research   \n",
+       "10  Transportation Research   \n",
+       "11  Transportation Research   \n",
+       "12  Transportation Research   \n",
+       "13  Transportation Research   \n",
+       "14  Transportation Research   \n",
+       "15  Transportation Research   \n",
+       "16  Transportation Research   \n",
+       "17  Transportation Research   \n",
+       "18  Transportation Research   \n",
+       "19  Transportation Research   \n",
+       "20  Transportation Research   \n",
+       "21  Transportation Research   \n",
+       "22  Transportation Research   \n",
+       "23  Transportation Research   \n",
+       "24  Transportation Research   \n",
+       "\n",
+       "                                              summary  \\\n",
+       "1    A novel traffic management strategy in automa...   \n",
+       "2    Areas of interventions for shared modes (Scho...   \n",
+       "3   This paper examines the transportation-growth ...   \n",
+       "4   Activity-based models appeared as an answer to...   \n",
+       "5   With the recent advances in battery technology...   \n",
+       "6    Reliable shortest problem with link travel ti...   \n",
+       "7    Reference models are dedicated to non-ordered...   \n",
+       "8    A queueing theory-based model for matching ta...   \n",
+       "9    We propose a link-based cyclic tradable credi...   \n",
+       "10  This paper addresses one of the most challengi...   \n",
+       "11   Mode and destination type choice were found t...   \n",
+       "12   Image processing algorithm developed for accu...   \n",
+       "13   A MIP model is built to improve the OD access...   \n",
+       "14   CAVs are capable of learning the optimal cont...   \n",
+       "15   A mixed integer linear model is developed to ...   \n",
+       "16   Vehicle platoon is a set of vehicles driving ...   \n",
+       "17   The relationship between commuting behaviour ...   \n",
+       "18   Health impact assessment of long-range transp...   \n",
+       "19   We monitored PM levels pre and post odd-even ...   \n",
+       "20   Interest in foldable ocean containers to addr...   \n",
+       "21   This study investigates the purchase intentio...   \n",
+       "22   Driving is a combination of top-down and bott...   \n",
+       "23   Distraction caused by a music player and phon...   \n",
+       "24   Drivers’ toll lane choices and their travel t...   \n",
+       "\n",
+       "                                                title  \n",
+       "1   Driving aggressiveness management policy to en...  \n",
+       "2   Identifying areas of interventions for improve...  \n",
+       "3   The Transportation-growth nexus in USA: Fresh ...  \n",
+       "4   Mobile phone records to feed activity-based tr...  \n",
+       "5   Optimizing the deployment of electric vehicle ...  \n",
+       "6   An algorithm for reliable shortest path proble...  \n",
+       "7   A new family of qualitative choice models: An ...  \n",
+       "8   A Markov decision process approach to vacant t...  \n",
+       "9   Promoting social equity with cyclic tradable c...  \n",
+       "10  Fair cost allocation for ridesharing services ...  \n",
+       "11  Modeling household-level hurricane evacuation ...  \n",
+       "12  Tracking vehicle trajectories and fuel rates i...  \n",
+       "13  Timetable synchronization of last trains for u...  \n",
+       "14  Deep reinforcement learning enabled self-learn...  \n",
+       "15  Coordinated optimization of tram trajectories ...  \n",
+       "16  Behaviorally stable vehicle platooning for ene...  \n",
+       "17  Commuting behavior and congestion satisfaction...  \n",
+       "18  Modeling health equity in active transportatio...  \n",
+       "19  The effect of odd-even driving scheme on PM2.5...  \n",
+       "20  The impact of foldable ocean containers on bac...  \n",
+       "21  Effect of environmental awareness on purchase ...  \n",
+       "22  Quantifying the difference between intention a...  \n",
+       "23  Driver behaviour at the onset of yellow signal...  \n",
+       "24  The effect of information on drivers’ toll lan...  "
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://www.detroitnews.com/autos/\n",
+      "5 new papers in Detroit News\n",
+      "https://www.journals.elsevier.com/transportation-research-part-a-policy-and-practice/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-b-methodological/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-c-emerging-technologies/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-d-transport-and-environment/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-e-logistics-and-transportation-review/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-f-traffic-psychology-and-behaviour/recent-articles\n",
+      "24 new papers in Transportation Research\n",
+      "https://www.journals.elsevier.com/journal-of-urban-economics/recent-articles\n",
+      "0 new papers in Journal of Urban Economics\n",
+      "https://www.journals.elsevier.com/transport-policy/recent-articles\n",
+      "0 new papers in Transport Policy\n"
+     ]
+    }
+   ],
+   "source": [
+    "driver = webdriver.Chrome()\n",
+    "week_o_papers = []\n",
+    "for site in selenium_dict:\n",
+    "    week_o_papers.append(css_scraypuh(selenium_dict[site]))\n",
+    "week_o_papers = pd.concat(week_o_papers)\n",
+    "#week_o_papers.to_excel('{} papers.xls'.format(search_date))\n",
     "week_o_papers.dropna(how='all', axis=0, inplace=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>link</th>\n",
+       "      <th>source</th>\n",
+       "      <th>summary</th>\n",
+       "      <th>title</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2019-01-18</td>\n",
+       "      <td>https://www.detroitnews.com/story/business/aut...</td>\n",
+       "      <td>Detroit News</td>\n",
+       "      <td>Tokyo – Mitsubishi Motors held a board meeting...</td>\n",
+       "      <td>Mitsubishi board examines new charges against ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2019-01-18</td>\n",
+       "      <td>https://www.detroitnews.com/story/business/aut...</td>\n",
+       "      <td>Detroit News</td>\n",
+       "      <td>Tesla, recognizing as imperative its ability t...</td>\n",
+       "      <td>Tesla to cut staff 7%, says road ahead very di...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.detroitnews.com/story/business/aut...</td>\n",
+       "      <td>Detroit News</td>\n",
+       "      <td>Detroit — The ongoing standoff between Preside...</td>\n",
+       "      <td>Bill Ford: Washington standoff is bad for busi...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.detroitnews.com/story/business/aut...</td>\n",
+       "      <td>Detroit News</td>\n",
+       "      <td>Four Audi AG officials have been indicted for ...</td>\n",
+       "      <td>Four Audi officials indicted for diesel cheating</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.detroitnews.com/story/news/local/m...</td>\n",
+       "      <td>Detroit News</td>\n",
+       "      <td>Detroit — Lt. Gov. Garlin Gilchrist II on Thur...</td>\n",
+       "      <td>Gilchrist makes Detroit auto show appearance t...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A novel traffic management strategy in automa...</td>\n",
+       "      <td>Driving aggressiveness management policy to en...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Areas of interventions for shared modes (Scho...</td>\n",
+       "      <td>Identifying areas of interventions for improve...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>This paper examines the transportation-growth ...</td>\n",
+       "      <td>The Transportation-growth nexus in USA: Fresh ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2019-01-12</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Activity-based models appeared as an answer to...</td>\n",
+       "      <td>Mobile phone records to feed activity-based tr...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>2019-01-12</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>With the recent advances in battery technology...</td>\n",
+       "      <td>Optimizing the deployment of electric vehicle ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Reliable shortest problem with link travel ti...</td>\n",
+       "      <td>An algorithm for reliable shortest path proble...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Reference models are dedicated to non-ordered...</td>\n",
+       "      <td>A new family of qualitative choice models: An ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A queueing theory-based model for matching ta...</td>\n",
+       "      <td>A Markov decision process approach to vacant t...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>2019-01-14</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>We propose a link-based cyclic tradable credi...</td>\n",
+       "      <td>Promoting social equity with cyclic tradable c...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>2019-01-12</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>This paper addresses one of the most challengi...</td>\n",
+       "      <td>Fair cost allocation for ridesharing services ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Mode and destination type choice were found t...</td>\n",
+       "      <td>Modeling household-level hurricane evacuation ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Image processing algorithm developed for accu...</td>\n",
+       "      <td>Tracking vehicle trajectories and fuel rates i...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A MIP model is built to improve the OD access...</td>\n",
+       "      <td>Timetable synchronization of last trains for u...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>CAVs are capable of learning the optimal cont...</td>\n",
+       "      <td>Deep reinforcement learning enabled self-learn...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A mixed integer linear model is developed to ...</td>\n",
+       "      <td>Coordinated optimization of tram trajectories ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Vehicle platoon is a set of vehicles driving ...</td>\n",
+       "      <td>Behaviorally stable vehicle platooning for ene...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>The relationship between commuting behaviour ...</td>\n",
+       "      <td>Commuting behavior and congestion satisfaction...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Health impact assessment of long-range transp...</td>\n",
+       "      <td>Modeling health equity in active transportatio...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>We monitored PM levels pre and post odd-even ...</td>\n",
+       "      <td>The effect of odd-even driving scheme on PM2.5...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Interest in foldable ocean containers to addr...</td>\n",
+       "      <td>The impact of foldable ocean containers on bac...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>This study investigates the purchase intentio...</td>\n",
+       "      <td>Effect of environmental awareness on purchase ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Driving is a combination of top-down and bott...</td>\n",
+       "      <td>Quantifying the difference between intention a...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Distraction caused by a music player and phon...</td>\n",
+       "      <td>Driver behaviour at the onset of yellow signal...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Drivers’ toll lane choices and their travel t...</td>\n",
+       "      <td>The effect of information on drivers’ toll lan...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          date                                               link  \\\n",
+       "1   2019-01-18  https://www.detroitnews.com/story/business/aut...   \n",
+       "2   2019-01-18  https://www.detroitnews.com/story/business/aut...   \n",
+       "3   2019-01-17  https://www.detroitnews.com/story/business/aut...   \n",
+       "4   2019-01-17  https://www.detroitnews.com/story/business/aut...   \n",
+       "5   2019-01-17  https://www.detroitnews.com/story/news/local/m...   \n",
+       "1   2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "2   2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "3   2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "4   2019-01-12  https://www.sciencedirect.com/science/article/...   \n",
+       "5   2019-01-12  https://www.sciencedirect.com/science/article/...   \n",
+       "6   2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "7   2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "8   2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "9   2019-01-14  https://www.sciencedirect.com/science/article/...   \n",
+       "10  2019-01-12  https://www.sciencedirect.com/science/article/...   \n",
+       "11  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "12  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "13  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "14  2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "15  2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "16  2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "17  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "18  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "19  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "20  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "21  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "22  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "23  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "24  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "\n",
+       "                     source  \\\n",
+       "1              Detroit News   \n",
+       "2              Detroit News   \n",
+       "3              Detroit News   \n",
+       "4              Detroit News   \n",
+       "5              Detroit News   \n",
+       "1   Transportation Research   \n",
+       "2   Transportation Research   \n",
+       "3   Transportation Research   \n",
+       "4   Transportation Research   \n",
+       "5   Transportation Research   \n",
+       "6   Transportation Research   \n",
+       "7   Transportation Research   \n",
+       "8   Transportation Research   \n",
+       "9   Transportation Research   \n",
+       "10  Transportation Research   \n",
+       "11  Transportation Research   \n",
+       "12  Transportation Research   \n",
+       "13  Transportation Research   \n",
+       "14  Transportation Research   \n",
+       "15  Transportation Research   \n",
+       "16  Transportation Research   \n",
+       "17  Transportation Research   \n",
+       "18  Transportation Research   \n",
+       "19  Transportation Research   \n",
+       "20  Transportation Research   \n",
+       "21  Transportation Research   \n",
+       "22  Transportation Research   \n",
+       "23  Transportation Research   \n",
+       "24  Transportation Research   \n",
+       "\n",
+       "                                              summary  \\\n",
+       "1   Tokyo – Mitsubishi Motors held a board meeting...   \n",
+       "2   Tesla, recognizing as imperative its ability t...   \n",
+       "3   Detroit — The ongoing standoff between Preside...   \n",
+       "4   Four Audi AG officials have been indicted for ...   \n",
+       "5   Detroit — Lt. Gov. Garlin Gilchrist II on Thur...   \n",
+       "1    A novel traffic management strategy in automa...   \n",
+       "2    Areas of interventions for shared modes (Scho...   \n",
+       "3   This paper examines the transportation-growth ...   \n",
+       "4   Activity-based models appeared as an answer to...   \n",
+       "5   With the recent advances in battery technology...   \n",
+       "6    Reliable shortest problem with link travel ti...   \n",
+       "7    Reference models are dedicated to non-ordered...   \n",
+       "8    A queueing theory-based model for matching ta...   \n",
+       "9    We propose a link-based cyclic tradable credi...   \n",
+       "10  This paper addresses one of the most challengi...   \n",
+       "11   Mode and destination type choice were found t...   \n",
+       "12   Image processing algorithm developed for accu...   \n",
+       "13   A MIP model is built to improve the OD access...   \n",
+       "14   CAVs are capable of learning the optimal cont...   \n",
+       "15   A mixed integer linear model is developed to ...   \n",
+       "16   Vehicle platoon is a set of vehicles driving ...   \n",
+       "17   The relationship between commuting behaviour ...   \n",
+       "18   Health impact assessment of long-range transp...   \n",
+       "19   We monitored PM levels pre and post odd-even ...   \n",
+       "20   Interest in foldable ocean containers to addr...   \n",
+       "21   This study investigates the purchase intentio...   \n",
+       "22   Driving is a combination of top-down and bott...   \n",
+       "23   Distraction caused by a music player and phon...   \n",
+       "24   Drivers’ toll lane choices and their travel t...   \n",
+       "\n",
+       "                                                title  \n",
+       "1   Mitsubishi board examines new charges against ...  \n",
+       "2   Tesla to cut staff 7%, says road ahead very di...  \n",
+       "3   Bill Ford: Washington standoff is bad for busi...  \n",
+       "4    Four Audi officials indicted for diesel cheating  \n",
+       "5   Gilchrist makes Detroit auto show appearance t...  \n",
+       "1   Driving aggressiveness management policy to en...  \n",
+       "2   Identifying areas of interventions for improve...  \n",
+       "3   The Transportation-growth nexus in USA: Fresh ...  \n",
+       "4   Mobile phone records to feed activity-based tr...  \n",
+       "5   Optimizing the deployment of electric vehicle ...  \n",
+       "6   An algorithm for reliable shortest path proble...  \n",
+       "7   A new family of qualitative choice models: An ...  \n",
+       "8   A Markov decision process approach to vacant t...  \n",
+       "9   Promoting social equity with cyclic tradable c...  \n",
+       "10  Fair cost allocation for ridesharing services ...  \n",
+       "11  Modeling household-level hurricane evacuation ...  \n",
+       "12  Tracking vehicle trajectories and fuel rates i...  \n",
+       "13  Timetable synchronization of last trains for u...  \n",
+       "14  Deep reinforcement learning enabled self-learn...  \n",
+       "15  Coordinated optimization of tram trajectories ...  \n",
+       "16  Behaviorally stable vehicle platooning for ene...  \n",
+       "17  Commuting behavior and congestion satisfaction...  \n",
+       "18  Modeling health equity in active transportatio...  \n",
+       "19  The effect of odd-even driving scheme on PM2.5...  \n",
+       "20  The impact of foldable ocean containers on bac...  \n",
+       "21  Effect of environmental awareness on purchase ...  \n",
+       "22  Quantifying the difference between intention a...  \n",
+       "23  Driver behaviour at the onset of yellow signal...  \n",
+       "24  The effect of information on drivers’ toll lan...  "
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "week_o_papers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-12-19T15:08:25.507884Z",
@@ -1324,7 +2823,888 @@
     },
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xe3c7b38>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20aba8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xdbf8608>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ad68>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20abe0>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xdbf8cc8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ad68>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xe3c7b38>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a7f0>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620108>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xc48a2e8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a358>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620ec8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xc48a2e8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xe3c7b38>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a710>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620088>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a908>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a828>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620348>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a908>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc6208c8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a828>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc6200c8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20afd0>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ac50>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620488>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20afd0>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ac50>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620488>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20afd0>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a2e8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc6209c8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a908>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620688>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a828>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620d08>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a390>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620288>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a908>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620288>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20af98>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620288>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a940>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620288>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a828>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620288>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a390>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb0b2048>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a908>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb0b2048>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20af98>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb0b28c8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a940>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620d08>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "newsdoc = docx.Document(docx='python_docx.docx')\n",
     "\n",
@@ -1340,7 +3720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-12-19T15:08:25.392357Z",

--- a/News_Scraping.ipynb
+++ b/News_Scraping.ipynb
@@ -16,11 +16,9 @@
     "* Axios\n",
     "* Functionality to add news article to SQL database after the fact\n",
     "* Auto open word doc in gen_docx\n",
-    "* Detroit News\n",
     "* Add Phys.org\n",
-    "* Transport Policy\n",
     "* [Journal of Modern Transportation](https://link.springer.com/journal/40534) -- add offline issues\n",
-    "* Journal of Urban Economics\n",
+    "* Add infinite scrolling functionality to css_scraypuh\n",
     "\n",
     "### Can't because of paywalls:\n",
     "* WSJ\n",
@@ -30,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-29T11:29:08.311107Z",
@@ -38,17 +36,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\EBarnard\\AppData\\Local\\Continuum\\anaconda3-1\\lib\\site-packages\\ipykernel\\parentpoller.py:116: UserWarning: Parent poll failed.  If the frontend dies,\n",
-      "                the kernel may be left running.  Please let us know\n",
-      "                about your system (bitness, Python, etc.) at\n",
-      "                ipython-dev@scipy.org\n",
-      "  ipython-dev@scipy.org\"\"\")\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -69,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-01-07T13:30:37.376863Z",
@@ -97,6 +84,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import sys\n",
     "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -119,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-01-07T13:30:37.453156Z",
@@ -171,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-01-07T13:30:37.503023Z",
@@ -427,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-01-07T13:30:37.531950Z",
@@ -583,7 +571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 29,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-01-07T13:30:37.588794Z",
@@ -883,6 +871,19 @@
     "                                     'sum_loc': \"[par for par in list(article.find('div', class_='post-content entry-content js_entry-content ').children) if str(par)[:3] =='<p>']\",\n",
     "                                     'title_loc': \"article.h1.text\",\n",
     "                                     'strain_bool': True},\n",
+    "                \n",
+    "                'Governing': {'url':  'http://www.governing.com/news/headlines',\n",
+    "                                     'source': 'Governing',\n",
+    "                                     'strain_tag': 'article',\n",
+    "                                     'strain_attr_name': 'class',\n",
+    "                                     'strain_attr_value': 'postlist__item--compact',\n",
+    "                                     'url_list_query': \"[article.a['href'] for article in self.base_soup.find_all('article', class_='postlist__item--compact')]\",\n",
+    "                                     'date_loc': \"article.time['datetime'].split('T')[0]\",\n",
+    "                                     'date_format': None,\n",
+    "                                     # The below method of searching for the summary filters out some odd divs in the middle of articles.\n",
+    "                                     'sum_loc': \"[par for par in list(article.find('div', class_='post-content entry-content js_entry-content ').children) if str(par)[:3] =='<p>']\",\n",
+    "                                     'title_loc': \"article.h1.text\",\n",
+    "                                     'strain_bool': True},\n",
     "                }"
    ]
   },
@@ -903,7 +904,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 30,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-01-07T13:37:17.149891Z",
@@ -915,10 +916,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "19 Jalopnik article(s) scraped\n",
-      "0 Jalopnik article(s) skipped due to error\n",
-      "1 Jalopnik article(s) skipped due to age\n",
-      "1 relevant article(s) collected\n"
+      "0 Governing article(s) scraped\n",
+      "0 Governing article(s) skipped due to error\n",
+      "0 Governing article(s) skipped due to age\n",
+      "0 relevant article(s) collected\n"
      ]
     }
    ],
@@ -927,7 +928,7 @@
     "scraypahs = {}\n",
     "temp_start_time = time.time()\n",
     "\n",
-    "name = 'Jalopnik'\n",
+    "name = 'Governing'\n",
     "scraypahs[name] = scraypah(scraper_dict[name])\n",
     "scraypahs[name].get_urls()\n",
     "scraypahs[name].scrape_em()\n",
@@ -1826,22 +1827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2018-12-19T15:07:50.946393Z",
-     "start_time": "2018-12-19T15:07:46.700321Z"
-    },
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "driver = webdriver.Chrome()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 32,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-12-19T15:07:50.976312Z",
@@ -1850,131 +1836,986 @@
    },
    "outputs": [],
    "source": [
-    "def paypuh_scraypuh(url, source):\n",
+    "def css_scraypuh(selenium_dict_value):\n",
     "    '''\n",
     "    bad_egg: Missing a key component (usually abstract), so skip printout/tracking\n",
     "    still_more: Date is still within past week, continue scraping!\n",
     "    '''\n",
-    "    soup = grab_homepage(url)\n",
-    "    papers_to_scrape = [paper.a['href'] for paper in soup.find_all(\n",
-    "        'div', attrs={'class': 'pod-listing-header'})]\n",
-    "    still_more = True\n",
+    "    max_age = 7 # take this out\n",
     "    scraped_count = 0\n",
     "    papers = {}\n",
-    "\n",
-    "    for paper in papers_to_scrape:\n",
-    "        #bad_egg bool becomes True if publication date of article can't be accessed.\n",
-    "        bad_egg = False \n",
-    "        if not still_more:\n",
-    "            break\n",
-    "        # Open article URL using selenium.\n",
-    "        driver.get(paper)\n",
-    "        # Get article publication date, title, and summary.\n",
-    "        try:\n",
-    "            driver.find_element_by_css_selector(\n",
-    "                \"span[class='CollapseText']\").click()\n",
-    "            date = pd.to_datetime(driver.find_element_by_css_selector(\n",
-    "                \"dl[class='articleDates smh']\").text.split('Available online ')[1]).date()\n",
+    "    \n",
+    "    # Important -- otherwise variables could be referenced before assignment.\n",
+    "    title = ''\n",
+    "    date = ''\n",
+    "    summary = ''\n",
+    "    \n",
+    "    if type(selenium_dict_value['url']) != list:\n",
+    "        selenium_dict_value['url'] = [selenium_dict_value['url']]\n",
+    "    for url in selenium_dict_value['url']:\n",
+    "        load_count = 0\n",
+    "        still_more = True\n",
+    "    \n",
+    "        driver.get(url)\n",
+    "        soup = BeautifulSoup(driver.page_source, \"html5lib\")\n",
+    "    \n",
+    "        # Click on CSS element to load more articles if available.\n",
+    "        if selenium_dict_value['load_more_css'] != None:\n",
+    "            for loadNo in range(selenium_dict_value['max_loads']):\n",
+    "                driver.find_element_by_css_selector(selenium_dict_value['load_more_css']).click()\n",
     "            soup = BeautifulSoup(driver.page_source, \"html5lib\")\n",
-    "            if (date - dt.date.today()).days > -max_age:\n",
-    "                title = soup.find('h1', class_='svTitle').text\n",
-    "                summary = soup.find(\n",
-    "                    'div', class_='abstract svAbstract ').p.text\n",
-    "            # If article is too old, set still_more = False.  This will break out of the for loop so that\n",
-    "            # paypuh_scraypuh() stops scraping papers from this source.\n",
-    "            else:\n",
-    "                still_more = False\n",
-    "        except:\n",
+    "        papers_to_scrape = eval(selenium_dict_value['url_list_query'])\n",
+    "        \n",
+    "        for paper in papers_to_scrape:\n",
+    "            bad_egg = False\n",
+    "            if not still_more or scraped_count > selenium_dict_value['max_scrapes']:\n",
+    "                break\n",
+    "            # Open article URL using selenium.\n",
+    "            driver.get(paper)\n",
+    "            soup = BeautifulSoup(driver.page_source, \"html5lib\")\n",
+    "            # Get article publication date, title, and summary.\n",
     "            try:\n",
-    "                # Use selenium to \"click\" the \"Show more\" button to reveal the date.\n",
-    "                driver.find_element_by_css_selector(\n",
-    "                    \"button[class='show-hide-details']\").click()\n",
-    "                soup = BeautifulSoup(driver.page_source, \"html5lib\")\n",
-    "                date = pd.to_datetime(soup.find('div', class_='wrapper').p.text.split(\n",
-    "                    'Available online ')[1]).date()\n",
-    "                # If age of article is less than max_age, get the article title and summary.\n",
-    "                if (date - dt.date.today()).days > -max_age:\n",
-    "                    title = soup.find('span', class_='title-text').text\n",
-    "                    summary = soup.find('div', class_='abstract author').p.text\n",
+    "                # Click on CSS element to reveal the location of the publication date if needed.\n",
+    "                if selenium_dict_value['date_css'] != None:\n",
+    "                    driver.find_element_by_css_selector(selenium_dict_value['date_css']).click()\n",
+    "                    soup = BeautifulSoup(driver.page_source, \"html5lib\")\n",
+    "                # Scrape the publication date.\n",
+    "                date = eval(selenium_dict_value['date_loc'])\n",
+    "                date = dt.datetime.strptime(date, selenium_dict_value['date_format']).date()\n",
+    "                # If the publication date shows the article is more recent than than max_age (in days) OR if articles are not \n",
+    "                # ordered by date (as in the case of Detroit News) scrape the title and summary.\n",
+    "                too_old = ((date - dt.date.today()).days <= -max_age)\n",
+    "                if not too_old:\n",
+    "                    # Click on CSS element to reveal the location of the title if needed.\n",
+    "                    if selenium_dict_value['title_css'] != None:\n",
+    "                        driver.find_element_by_css_selector(selenium_dict_value['title_css']).click()\n",
+    "                        soup = BeautifulSoup(driver.page_source, \"html5lib\")\n",
+    "                    # Scrape and clean the title.\n",
+    "                    title = eval(selenium_dict_value['title_loc'])\n",
+    "                    title = replace_em(title)\n",
+    "                    # Click on CSS element to reveal the location of the summary if needed.\n",
+    "                    if selenium_dict_value['sum_css'] != None:\n",
+    "                        driver.find_element_by_css_selector(selenium_dict_value['sum_css']).click()\n",
+    "                        soup = BeautifulSoup(driver.page_source, \"html5lib\")\n",
+    "                    # Scrape and clean the summary.\n",
+    "                    summary = eval(selenium_dict_value['sum_loc'])\n",
+    "                    summary = ' '.join([replace_em(p.text) for p in summary]) # Assumes that the summary is a list of paragraphs.\n",
+    "                    scraped_count += 1 \n",
+    "                    papers[scraped_count] = {\n",
+    "                            'title': title, 'summary': summary, 'link': paper, \n",
+    "                            'source': selenium_dict_value['source'], 'date': date}\n",
+    "                    \n",
+    "                # If article is too old, set still_more = False (if articles are ordered by date).  \n",
+    "                # This will break out of the for loop so that paypuh_scraypuh() stops scraping papers from this source.\n",
     "                else:\n",
-    "                    still_more = False\n",
-    "            # If publication date can't be accessed, skip article.\n",
-    "            except:\n",
+    "                    if selenium_dict_value['ordered_bool']:\n",
+    "                        still_more = False\n",
+    "            \n",
+    "            except Exception as e:\n",
     "                bad_egg = True\n",
-    "                print('bad egg in {}: {}'.format(source, paper))\n",
+    "                #print('bad egg in {}: {}'.format(selenium_dict_value['source'], paper))\n",
+    "                # Print out exception info.\n",
+    "                #print('Exception info: ', sys.exc_info(), '\\n')\n",
     "                pass\n",
-    "        scraped_count += 1\n",
-    "\n",
-    "        if still_more and not bad_egg:\n",
-    "            papers[scraped_count] = {\n",
-    "                'title': title, 'summary': summary, 'link': paper, 'source': source, 'date': date}\n",
-    "\n",
+    "            \n",
     "    # Print the number of papers scraped from each source.\n",
-    "    print('{} new papers in {}'.format(scraped_count, source))\n",
+    "    print('{} new papers in {}'.format(scraped_count, selenium_dict_value['source']))\n",
     "    return pd.DataFrame(papers).T"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 25,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-12-19T15:08:24.521491Z",
      "start_time": "2018-12-19T15:07:50.999251Z"
     }
    },
+   "outputs": [],
+   "source": [
+    "# sum_loc must provide directions for finding a list of paragraphs (not just paragraph text).\n",
+    "selenium_dict = {\n",
+    "                    'Detroit News': {'url': 'https://www.detroitnews.com/autos/',\n",
+    "                                     'source': 'Detroit News',\n",
+    "                                     'url_list_query': \"['https://www.detroitnews.com' + a['href'] for a in soup.find('div', class_='headline-page active').find_all('a')]\",\n",
+    "                                     'load_more_css': \"a.button-add-content\",\n",
+    "                                     'max_scrapes': 30,\n",
+    "                                     'max_loads': 2, # Make sure that loads is not too many -- otherwise load button may become inactive.  Test this.\n",
+    "                                     'ordered_bool': False,\n",
+    "                                     'date_css': None,\n",
+    "                                     'date_loc': \"soup.find('span', class_='asset-metabar-time asset-metabar-item nobyline').text.split('ET ')[1].split(' |')[0]\",\n",
+    "                                     'date_format': '%b. %d, %Y',\n",
+    "                                     'sum_css': None,\n",
+    "                                     'sum_loc': \"[soup.find('p', class_='speakable-p-1 p-text'), soup.find('p', class_='speakable-p-2 p-text')]\",\n",
+    "                                     'title_loc': \"soup.find('h1', class_='asset-headline speakable-headline').text\",\n",
+    "                                     'title_css': None},\n",
+    "                                 \n",
+    "                        'Transportation Research': {'url': ['https://www.journals.elsevier.com/transportation-research-part-a-policy-and-practice/recent-articles',\n",
+    "                                                            'https://www.journals.elsevier.com/transportation-research-part-b-methodological/recent-articles',\n",
+    "                                                            'https://www.journals.elsevier.com/transportation-research-part-c-emerging-technologies/recent-articles',\n",
+    "                                                            'https://www.journals.elsevier.com/transportation-research-part-d-transport-and-environment/recent-articles',\n",
+    "                                                            'https://www.journals.elsevier.com/transportation-research-part-e-logistics-and-transportation-review/recent-articles',\n",
+    "                                                            'https://www.journals.elsevier.com/transportation-research-part-f-traffic-psychology-and-behaviour/recent-articles' \n",
+    "                                                           ],\n",
+    "                                     'source': 'Transportation Research',\n",
+    "                                     'url_list_query': \"[div.a['href'] for div in soup.find_all('div', class_='pod-listing-header')]\",\n",
+    "                                     'load_more_css': None,\n",
+    "                                     'max_scrapes': 100,\n",
+    "                                     'max_loads': None,\n",
+    "                                     'ordered_bool': True,\n",
+    "                                     'date_css': \"button.show-hide-details\",\n",
+    "                                     'date_loc': \"soup.find('div', 'wrapper').p.text.split('online ')[1][:-1]\",\n",
+    "                                     'date_format': '%d %B %Y',\n",
+    "                                     'sum_css': None,\n",
+    "                                     'sum_loc': \"soup.find('div', class_='Abstracts').find_all('p', limit = 3)\",\n",
+    "                                     'title_loc': \"soup.h1.text\",\n",
+    "                                     'title_css': None},\n",
+    "    \n",
+    "                            'Journal of Urban Economics': {'url': 'https://www.journals.elsevier.com/journal-of-urban-economics/recent-articles',\n",
+    "                                     'source': 'Journal of Urban Economics',\n",
+    "                                     'url_list_query': \"[div.a['href'] for div in soup.find_all('div', class_='pod-listing-header')]\",\n",
+    "                                     'load_more_css': None,\n",
+    "                                     'max_scrapes': 100,\n",
+    "                                     'max_loads': None,\n",
+    "                                     'ordered_bool': True,\n",
+    "                                     'date_css': \"button.show-hide-details\",\n",
+    "                                     'date_loc': \"soup.find('div', 'wrapper').p.text.split('online ')[1][:-1]\",\n",
+    "                                     'date_format': '%d %B %Y',\n",
+    "                                     'sum_css': None,\n",
+    "                                     'sum_loc': \"soup.find('div', class_='Abstracts').find_all('p', limit = 3)\",\n",
+    "                                     'title_loc': \"soup.h1.text\",\n",
+    "                                     'title_css': None},\n",
+    "    \n",
+    "                            'Transport Policy': {'url': 'https://www.journals.elsevier.com/transport-policy/recent-articles',\n",
+    "                                     'source': 'Transport Policy',\n",
+    "                                     'url_list_query': \"[div.a['href'] for div in soup.find_all('div', class_='pod-listing-header')]\",\n",
+    "                                     'load_more_css': None,\n",
+    "                                     'max_scrapes': 100,\n",
+    "                                     'max_loads': None,\n",
+    "                                     'ordered_bool': True,\n",
+    "                                     'date_css': \"button.show-hide-details\",\n",
+    "                                     'date_loc': \"soup.find('div', 'wrapper').p.text.split('online ')[1][:-1]\",\n",
+    "                                     'date_format': '%d %B %Y',\n",
+    "                                     'sum_css': None,\n",
+    "                                     'sum_loc': \"soup.find('div', class_='Abstracts').find_all('p', limit = 3)\",\n",
+    "                                     'title_loc': \"soup.h1.text\",\n",
+    "                                     'title_css': None}\n",
+    "                                     }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "11 new papers in Transportation Part A\n",
-      "4 new papers in Transportation Part B\n",
-      "2 new papers in Transportation Part C\n",
-      "2 new papers in Transportation Part D\n",
-      "6 new papers in Transportation Part E\n",
-      "3 new papers in Transportation Part F\n",
-      "1 new papers in Journal of Urban Economics\n"
+      "https://www.journals.elsevier.com/transportation-research-part-a-policy-and-practice/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-b-methodological/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-c-emerging-technologies/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-d-transport-and-environment/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-e-logistics-and-transportation-review/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-f-traffic-psychology-and-behaviour/recent-articles\n",
+      "24 new papers in Transportation Research\n"
      ]
     }
    ],
    "source": [
-    "tparta = paypuh_scraypuh(\n",
-    "    'https://www.journals.elsevier.com/transportation-research-part-a-policy-and-practice/recent-articles', 'Transportation Part A')\n",
-    "tpartb = paypuh_scraypuh(\n",
-    "    'https://www.journals.elsevier.com/transportation-research-part-b-methodological/recent-articles', 'Transportation Part B')\n",
-    "tpartc = paypuh_scraypuh(\n",
-    "    'https://www.journals.elsevier.com/transportation-research-part-c-emerging-technologies/recent-articles', 'Transportation Part C')\n",
-    "tpartd = paypuh_scraypuh(\n",
-    "    'https://www.journals.elsevier.com/transportation-research-part-d-transport-and-environment/recent-articles', 'Transportation Part D')\n",
-    "tparte = paypuh_scraypuh(\n",
-    "    'https://www.journals.elsevier.com/transportation-research-part-e-logistics-and-transportation-review/recent-articles', 'Transportation Part E')\n",
-    "tpartf = paypuh_scraypuh(\n",
-    "    'https://www.journals.elsevier.com/transportation-research-part-f-traffic-psychology-and-behaviour/recent-articles', 'Transportation Part F')\n",
-    "\n",
-    "# Journal of Urban Economics -- not working correctly yet due to date format\n",
-    "joee = paypuh_scraypuh('https://www.journals.elsevier.com/journal-of-urban-economics/recent-articles', 'Journal of Urban Economics')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2018-12-19T15:08:24.871548Z",
-     "start_time": "2018-12-19T15:08:24.861576Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "week_o_papers = pd.concat([tparta, tpartb, tpartc, tpartd, tparte, tpartf, joee])\n",
-    "# week_o_papers.to_excel('{} papers.xls'.format(search_date))\n",
-    "week_o_papers.dropna(how='all', axis=0, inplace=True)"
+    "driver = webdriver.Chrome()\n",
+    "df = css_scraypuh(selenium_dict['Transportation Research'])"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>link</th>\n",
+       "      <th>source</th>\n",
+       "      <th>summary</th>\n",
+       "      <th>title</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A novel traffic management strategy in automa...</td>\n",
+       "      <td>Driving aggressiveness management policy to en...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Areas of interventions for shared modes (Scho...</td>\n",
+       "      <td>Identifying areas of interventions for improve...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>This paper examines the transportation-growth ...</td>\n",
+       "      <td>The Transportation-growth nexus in USA: Fresh ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2019-01-12</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Activity-based models appeared as an answer to...</td>\n",
+       "      <td>Mobile phone records to feed activity-based tr...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>2019-01-12</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>With the recent advances in battery technology...</td>\n",
+       "      <td>Optimizing the deployment of electric vehicle ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Reliable shortest problem with link travel ti...</td>\n",
+       "      <td>An algorithm for reliable shortest path proble...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Reference models are dedicated to non-ordered...</td>\n",
+       "      <td>A new family of qualitative choice models: An ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A queueing theory-based model for matching ta...</td>\n",
+       "      <td>A Markov decision process approach to vacant t...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>2019-01-14</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>We propose a link-based cyclic tradable credi...</td>\n",
+       "      <td>Promoting social equity with cyclic tradable c...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>2019-01-12</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>This paper addresses one of the most challengi...</td>\n",
+       "      <td>Fair cost allocation for ridesharing services ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Mode and destination type choice were found t...</td>\n",
+       "      <td>Modeling household-level hurricane evacuation ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Image processing algorithm developed for accu...</td>\n",
+       "      <td>Tracking vehicle trajectories and fuel rates i...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A MIP model is built to improve the OD access...</td>\n",
+       "      <td>Timetable synchronization of last trains for u...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>CAVs are capable of learning the optimal cont...</td>\n",
+       "      <td>Deep reinforcement learning enabled self-learn...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A mixed integer linear model is developed to ...</td>\n",
+       "      <td>Coordinated optimization of tram trajectories ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Vehicle platoon is a set of vehicles driving ...</td>\n",
+       "      <td>Behaviorally stable vehicle platooning for ene...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>The relationship between commuting behaviour ...</td>\n",
+       "      <td>Commuting behavior and congestion satisfaction...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Health impact assessment of long-range transp...</td>\n",
+       "      <td>Modeling health equity in active transportatio...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>We monitored PM levels pre and post odd-even ...</td>\n",
+       "      <td>The effect of odd-even driving scheme on PM2.5...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Interest in foldable ocean containers to addr...</td>\n",
+       "      <td>The impact of foldable ocean containers on bac...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>This study investigates the purchase intentio...</td>\n",
+       "      <td>Effect of environmental awareness on purchase ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Driving is a combination of top-down and bott...</td>\n",
+       "      <td>Quantifying the difference between intention a...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Distraction caused by a music player and phon...</td>\n",
+       "      <td>Driver behaviour at the onset of yellow signal...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Drivers’ toll lane choices and their travel t...</td>\n",
+       "      <td>The effect of information on drivers’ toll lan...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          date                                               link  \\\n",
+       "1   2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "2   2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "3   2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "4   2019-01-12  https://www.sciencedirect.com/science/article/...   \n",
+       "5   2019-01-12  https://www.sciencedirect.com/science/article/...   \n",
+       "6   2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "7   2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "8   2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "9   2019-01-14  https://www.sciencedirect.com/science/article/...   \n",
+       "10  2019-01-12  https://www.sciencedirect.com/science/article/...   \n",
+       "11  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "12  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "13  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "14  2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "15  2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "16  2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "17  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "18  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "19  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "20  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "21  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "22  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "23  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "24  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "\n",
+       "                     source  \\\n",
+       "1   Transportation Research   \n",
+       "2   Transportation Research   \n",
+       "3   Transportation Research   \n",
+       "4   Transportation Research   \n",
+       "5   Transportation Research   \n",
+       "6   Transportation Research   \n",
+       "7   Transportation Research   \n",
+       "8   Transportation Research   \n",
+       "9   Transportation Research   \n",
+       "10  Transportation Research   \n",
+       "11  Transportation Research   \n",
+       "12  Transportation Research   \n",
+       "13  Transportation Research   \n",
+       "14  Transportation Research   \n",
+       "15  Transportation Research   \n",
+       "16  Transportation Research   \n",
+       "17  Transportation Research   \n",
+       "18  Transportation Research   \n",
+       "19  Transportation Research   \n",
+       "20  Transportation Research   \n",
+       "21  Transportation Research   \n",
+       "22  Transportation Research   \n",
+       "23  Transportation Research   \n",
+       "24  Transportation Research   \n",
+       "\n",
+       "                                              summary  \\\n",
+       "1    A novel traffic management strategy in automa...   \n",
+       "2    Areas of interventions for shared modes (Scho...   \n",
+       "3   This paper examines the transportation-growth ...   \n",
+       "4   Activity-based models appeared as an answer to...   \n",
+       "5   With the recent advances in battery technology...   \n",
+       "6    Reliable shortest problem with link travel ti...   \n",
+       "7    Reference models are dedicated to non-ordered...   \n",
+       "8    A queueing theory-based model for matching ta...   \n",
+       "9    We propose a link-based cyclic tradable credi...   \n",
+       "10  This paper addresses one of the most challengi...   \n",
+       "11   Mode and destination type choice were found t...   \n",
+       "12   Image processing algorithm developed for accu...   \n",
+       "13   A MIP model is built to improve the OD access...   \n",
+       "14   CAVs are capable of learning the optimal cont...   \n",
+       "15   A mixed integer linear model is developed to ...   \n",
+       "16   Vehicle platoon is a set of vehicles driving ...   \n",
+       "17   The relationship between commuting behaviour ...   \n",
+       "18   Health impact assessment of long-range transp...   \n",
+       "19   We monitored PM levels pre and post odd-even ...   \n",
+       "20   Interest in foldable ocean containers to addr...   \n",
+       "21   This study investigates the purchase intentio...   \n",
+       "22   Driving is a combination of top-down and bott...   \n",
+       "23   Distraction caused by a music player and phon...   \n",
+       "24   Drivers’ toll lane choices and their travel t...   \n",
+       "\n",
+       "                                                title  \n",
+       "1   Driving aggressiveness management policy to en...  \n",
+       "2   Identifying areas of interventions for improve...  \n",
+       "3   The Transportation-growth nexus in USA: Fresh ...  \n",
+       "4   Mobile phone records to feed activity-based tr...  \n",
+       "5   Optimizing the deployment of electric vehicle ...  \n",
+       "6   An algorithm for reliable shortest path proble...  \n",
+       "7   A new family of qualitative choice models: An ...  \n",
+       "8   A Markov decision process approach to vacant t...  \n",
+       "9   Promoting social equity with cyclic tradable c...  \n",
+       "10  Fair cost allocation for ridesharing services ...  \n",
+       "11  Modeling household-level hurricane evacuation ...  \n",
+       "12  Tracking vehicle trajectories and fuel rates i...  \n",
+       "13  Timetable synchronization of last trains for u...  \n",
+       "14  Deep reinforcement learning enabled self-learn...  \n",
+       "15  Coordinated optimization of tram trajectories ...  \n",
+       "16  Behaviorally stable vehicle platooning for ene...  \n",
+       "17  Commuting behavior and congestion satisfaction...  \n",
+       "18  Modeling health equity in active transportatio...  \n",
+       "19  The effect of odd-even driving scheme on PM2.5...  \n",
+       "20  The impact of foldable ocean containers on bac...  \n",
+       "21  Effect of environmental awareness on purchase ...  \n",
+       "22  Quantifying the difference between intention a...  \n",
+       "23  Driver behaviour at the onset of yellow signal...  \n",
+       "24  The effect of information on drivers’ toll lan...  "
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://www.detroitnews.com/autos/\n",
+      "5 new papers in Detroit News\n",
+      "https://www.journals.elsevier.com/transportation-research-part-a-policy-and-practice/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-b-methodological/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-c-emerging-technologies/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-d-transport-and-environment/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-e-logistics-and-transportation-review/recent-articles\n",
+      "https://www.journals.elsevier.com/transportation-research-part-f-traffic-psychology-and-behaviour/recent-articles\n",
+      "24 new papers in Transportation Research\n",
+      "https://www.journals.elsevier.com/journal-of-urban-economics/recent-articles\n",
+      "0 new papers in Journal of Urban Economics\n",
+      "https://www.journals.elsevier.com/transport-policy/recent-articles\n",
+      "0 new papers in Transport Policy\n"
+     ]
+    }
+   ],
+   "source": [
+    "driver = webdriver.Chrome()\n",
+    "week_o_papers = []\n",
+    "for site in selenium_dict:\n",
+    "    week_o_papers.append(css_scraypuh(selenium_dict[site]))\n",
+    "week_o_papers = pd.concat(week_o_papers)\n",
+    "#week_o_papers.to_excel('{} papers.xls'.format(search_date))\n",
+    "week_o_papers.dropna(how='all', axis=0, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>link</th>\n",
+       "      <th>source</th>\n",
+       "      <th>summary</th>\n",
+       "      <th>title</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2019-01-18</td>\n",
+       "      <td>https://www.detroitnews.com/story/business/aut...</td>\n",
+       "      <td>Detroit News</td>\n",
+       "      <td>Tokyo – Mitsubishi Motors held a board meeting...</td>\n",
+       "      <td>Mitsubishi board examines new charges against ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2019-01-18</td>\n",
+       "      <td>https://www.detroitnews.com/story/business/aut...</td>\n",
+       "      <td>Detroit News</td>\n",
+       "      <td>Tesla, recognizing as imperative its ability t...</td>\n",
+       "      <td>Tesla to cut staff 7%, says road ahead very di...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.detroitnews.com/story/business/aut...</td>\n",
+       "      <td>Detroit News</td>\n",
+       "      <td>Detroit — The ongoing standoff between Preside...</td>\n",
+       "      <td>Bill Ford: Washington standoff is bad for busi...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.detroitnews.com/story/business/aut...</td>\n",
+       "      <td>Detroit News</td>\n",
+       "      <td>Four Audi AG officials have been indicted for ...</td>\n",
+       "      <td>Four Audi officials indicted for diesel cheating</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.detroitnews.com/story/news/local/m...</td>\n",
+       "      <td>Detroit News</td>\n",
+       "      <td>Detroit — Lt. Gov. Garlin Gilchrist II on Thur...</td>\n",
+       "      <td>Gilchrist makes Detroit auto show appearance t...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A novel traffic management strategy in automa...</td>\n",
+       "      <td>Driving aggressiveness management policy to en...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Areas of interventions for shared modes (Scho...</td>\n",
+       "      <td>Identifying areas of interventions for improve...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>This paper examines the transportation-growth ...</td>\n",
+       "      <td>The Transportation-growth nexus in USA: Fresh ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2019-01-12</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Activity-based models appeared as an answer to...</td>\n",
+       "      <td>Mobile phone records to feed activity-based tr...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>2019-01-12</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>With the recent advances in battery technology...</td>\n",
+       "      <td>Optimizing the deployment of electric vehicle ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Reliable shortest problem with link travel ti...</td>\n",
+       "      <td>An algorithm for reliable shortest path proble...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Reference models are dedicated to non-ordered...</td>\n",
+       "      <td>A new family of qualitative choice models: An ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A queueing theory-based model for matching ta...</td>\n",
+       "      <td>A Markov decision process approach to vacant t...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>2019-01-14</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>We propose a link-based cyclic tradable credi...</td>\n",
+       "      <td>Promoting social equity with cyclic tradable c...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>2019-01-12</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>This paper addresses one of the most challengi...</td>\n",
+       "      <td>Fair cost allocation for ridesharing services ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Mode and destination type choice were found t...</td>\n",
+       "      <td>Modeling household-level hurricane evacuation ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Image processing algorithm developed for accu...</td>\n",
+       "      <td>Tracking vehicle trajectories and fuel rates i...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A MIP model is built to improve the OD access...</td>\n",
+       "      <td>Timetable synchronization of last trains for u...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>CAVs are capable of learning the optimal cont...</td>\n",
+       "      <td>Deep reinforcement learning enabled self-learn...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>A mixed integer linear model is developed to ...</td>\n",
+       "      <td>Coordinated optimization of tram trajectories ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>2019-01-15</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Vehicle platoon is a set of vehicles driving ...</td>\n",
+       "      <td>Behaviorally stable vehicle platooning for ene...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>The relationship between commuting behaviour ...</td>\n",
+       "      <td>Commuting behavior and congestion satisfaction...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Health impact assessment of long-range transp...</td>\n",
+       "      <td>Modeling health equity in active transportatio...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>We monitored PM levels pre and post odd-even ...</td>\n",
+       "      <td>The effect of odd-even driving scheme on PM2.5...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Interest in foldable ocean containers to addr...</td>\n",
+       "      <td>The impact of foldable ocean containers on bac...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>This study investigates the purchase intentio...</td>\n",
+       "      <td>Effect of environmental awareness on purchase ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>2019-01-16</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Driving is a combination of top-down and bott...</td>\n",
+       "      <td>Quantifying the difference between intention a...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Distraction caused by a music player and phon...</td>\n",
+       "      <td>Driver behaviour at the onset of yellow signal...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>2019-01-17</td>\n",
+       "      <td>https://www.sciencedirect.com/science/article/...</td>\n",
+       "      <td>Transportation Research</td>\n",
+       "      <td>Drivers’ toll lane choices and their travel t...</td>\n",
+       "      <td>The effect of information on drivers’ toll lan...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          date                                               link  \\\n",
+       "1   2019-01-18  https://www.detroitnews.com/story/business/aut...   \n",
+       "2   2019-01-18  https://www.detroitnews.com/story/business/aut...   \n",
+       "3   2019-01-17  https://www.detroitnews.com/story/business/aut...   \n",
+       "4   2019-01-17  https://www.detroitnews.com/story/business/aut...   \n",
+       "5   2019-01-17  https://www.detroitnews.com/story/news/local/m...   \n",
+       "1   2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "2   2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "3   2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "4   2019-01-12  https://www.sciencedirect.com/science/article/...   \n",
+       "5   2019-01-12  https://www.sciencedirect.com/science/article/...   \n",
+       "6   2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "7   2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "8   2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "9   2019-01-14  https://www.sciencedirect.com/science/article/...   \n",
+       "10  2019-01-12  https://www.sciencedirect.com/science/article/...   \n",
+       "11  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "12  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "13  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "14  2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "15  2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "16  2019-01-15  https://www.sciencedirect.com/science/article/...   \n",
+       "17  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "18  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "19  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "20  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "21  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "22  2019-01-16  https://www.sciencedirect.com/science/article/...   \n",
+       "23  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "24  2019-01-17  https://www.sciencedirect.com/science/article/...   \n",
+       "\n",
+       "                     source  \\\n",
+       "1              Detroit News   \n",
+       "2              Detroit News   \n",
+       "3              Detroit News   \n",
+       "4              Detroit News   \n",
+       "5              Detroit News   \n",
+       "1   Transportation Research   \n",
+       "2   Transportation Research   \n",
+       "3   Transportation Research   \n",
+       "4   Transportation Research   \n",
+       "5   Transportation Research   \n",
+       "6   Transportation Research   \n",
+       "7   Transportation Research   \n",
+       "8   Transportation Research   \n",
+       "9   Transportation Research   \n",
+       "10  Transportation Research   \n",
+       "11  Transportation Research   \n",
+       "12  Transportation Research   \n",
+       "13  Transportation Research   \n",
+       "14  Transportation Research   \n",
+       "15  Transportation Research   \n",
+       "16  Transportation Research   \n",
+       "17  Transportation Research   \n",
+       "18  Transportation Research   \n",
+       "19  Transportation Research   \n",
+       "20  Transportation Research   \n",
+       "21  Transportation Research   \n",
+       "22  Transportation Research   \n",
+       "23  Transportation Research   \n",
+       "24  Transportation Research   \n",
+       "\n",
+       "                                              summary  \\\n",
+       "1   Tokyo – Mitsubishi Motors held a board meeting...   \n",
+       "2   Tesla, recognizing as imperative its ability t...   \n",
+       "3   Detroit — The ongoing standoff between Preside...   \n",
+       "4   Four Audi AG officials have been indicted for ...   \n",
+       "5   Detroit — Lt. Gov. Garlin Gilchrist II on Thur...   \n",
+       "1    A novel traffic management strategy in automa...   \n",
+       "2    Areas of interventions for shared modes (Scho...   \n",
+       "3   This paper examines the transportation-growth ...   \n",
+       "4   Activity-based models appeared as an answer to...   \n",
+       "5   With the recent advances in battery technology...   \n",
+       "6    Reliable shortest problem with link travel ti...   \n",
+       "7    Reference models are dedicated to non-ordered...   \n",
+       "8    A queueing theory-based model for matching ta...   \n",
+       "9    We propose a link-based cyclic tradable credi...   \n",
+       "10  This paper addresses one of the most challengi...   \n",
+       "11   Mode and destination type choice were found t...   \n",
+       "12   Image processing algorithm developed for accu...   \n",
+       "13   A MIP model is built to improve the OD access...   \n",
+       "14   CAVs are capable of learning the optimal cont...   \n",
+       "15   A mixed integer linear model is developed to ...   \n",
+       "16   Vehicle platoon is a set of vehicles driving ...   \n",
+       "17   The relationship between commuting behaviour ...   \n",
+       "18   Health impact assessment of long-range transp...   \n",
+       "19   We monitored PM levels pre and post odd-even ...   \n",
+       "20   Interest in foldable ocean containers to addr...   \n",
+       "21   This study investigates the purchase intentio...   \n",
+       "22   Driving is a combination of top-down and bott...   \n",
+       "23   Distraction caused by a music player and phon...   \n",
+       "24   Drivers’ toll lane choices and their travel t...   \n",
+       "\n",
+       "                                                title  \n",
+       "1   Mitsubishi board examines new charges against ...  \n",
+       "2   Tesla to cut staff 7%, says road ahead very di...  \n",
+       "3   Bill Ford: Washington standoff is bad for busi...  \n",
+       "4    Four Audi officials indicted for diesel cheating  \n",
+       "5   Gilchrist makes Detroit auto show appearance t...  \n",
+       "1   Driving aggressiveness management policy to en...  \n",
+       "2   Identifying areas of interventions for improve...  \n",
+       "3   The Transportation-growth nexus in USA: Fresh ...  \n",
+       "4   Mobile phone records to feed activity-based tr...  \n",
+       "5   Optimizing the deployment of electric vehicle ...  \n",
+       "6   An algorithm for reliable shortest path proble...  \n",
+       "7   A new family of qualitative choice models: An ...  \n",
+       "8   A Markov decision process approach to vacant t...  \n",
+       "9   Promoting social equity with cyclic tradable c...  \n",
+       "10  Fair cost allocation for ridesharing services ...  \n",
+       "11  Modeling household-level hurricane evacuation ...  \n",
+       "12  Tracking vehicle trajectories and fuel rates i...  \n",
+       "13  Timetable synchronization of last trains for u...  \n",
+       "14  Deep reinforcement learning enabled self-learn...  \n",
+       "15  Coordinated optimization of tram trajectories ...  \n",
+       "16  Behaviorally stable vehicle platooning for ene...  \n",
+       "17  Commuting behavior and congestion satisfaction...  \n",
+       "18  Modeling health equity in active transportatio...  \n",
+       "19  The effect of odd-even driving scheme on PM2.5...  \n",
+       "20  The impact of foldable ocean containers on bac...  \n",
+       "21  Effect of environmental awareness on purchase ...  \n",
+       "22  Quantifying the difference between intention a...  \n",
+       "23  Driver behaviour at the onset of yellow signal...  \n",
+       "24  The effect of information on drivers’ toll lan...  "
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "week_o_papers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-12-19T15:08:25.507884Z",
@@ -1986,320 +2827,240 @@
     {
      "data": {
       "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
+       "<docx.text.paragraph.Paragraph at 0xe3c7b38>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c72e8>"
+       "<docx.text.run.Run at 0xb20aba8>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc662bc8>"
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xdbf8608>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c7f98>"
+       "<docx.text.run.Run at 0xb20ad68>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a588>"
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c79b0>"
+       "<docx.text.run.Run at 0xb20abe0>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc983608>"
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xdbf8cc8>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c7f98>"
+       "<docx.text.run.Run at 0xb20ad68>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
+       "<docx.text.paragraph.Paragraph at 0xe3c7b38>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c7d68>"
+       "<docx.text.run.Run at 0xb20a7f0>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc983a08>"
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620108>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
+       "<docx.text.run.Run at 0xc48a2e8>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a588>"
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c7c50>"
+       "<docx.text.run.Run at 0xb20a358>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944f48>"
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620ec8>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
+       "<docx.text.run.Run at 0xc48a2e8>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
+       "<docx.text.paragraph.Paragraph at 0xe3c7b38>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c7320>"
+       "<docx.text.run.Run at 0xb20a710>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944688>"
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620088>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
+       "<docx.text.run.Run at 0xb20a908>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a588>"
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c79b0>"
+       "<docx.text.run.Run at 0xb20a828>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb9440c8>"
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620348>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
+       "<docx.text.run.Run at 0xb20a908>"
       ]
      },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xe3c7d30>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944d08>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a588>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xe3c7160>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944788>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
-      ]
-     },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2309,157 +3070,77 @@
        "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c7be0>"
+       "<docx.text.run.Run at 0xb20a208>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb93cfc8>"
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc6208c8>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
+       "<docx.text.run.Run at 0xb20a828>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a588>"
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c7f60>"
+       "<docx.text.run.Run at 0xb20a208>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944d08>"
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc6200c8>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
+       "<docx.text.run.Run at 0xb20afd0>"
       ]
      },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xe3c73c8>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944d08>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a588>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xe3c73c8>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944d08>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
-      ]
-     },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2469,157 +3150,77 @@
        "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c7dd8>"
+       "<docx.text.run.Run at 0xb20ac50>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944d08>"
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620488>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
+       "<docx.text.run.Run at 0xb20afd0>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a588>"
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c7be0>"
+       "<docx.text.run.Run at 0xb20ac50>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944d08>"
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620488>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
+       "<docx.text.run.Run at 0xb20afd0>"
       ]
      },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xe3c77f0>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944d08>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a588>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xe3c7208>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944d08>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
-      ]
-     },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2629,157 +3230,77 @@
        "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c78d0>"
+       "<docx.text.run.Run at 0xb20a2e8>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944d08>"
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc6209c8>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
+       "<docx.text.run.Run at 0xb20ae80>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a588>"
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c7b38>"
+       "<docx.text.run.Run at 0xb20a908>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944d08>"
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620688>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
+       "<docx.text.run.Run at 0xb20ae80>"
       ]
      },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xe3c7a90>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944d08>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xc48a588>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xe3c78d0>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944d08>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
-      ]
-     },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2789,96 +3310,399 @@
        "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c7860>"
+       "<docx.text.run.Run at 0xb20a828>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944d08>"
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620d08>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
+       "<docx.text.run.Run at 0xb20ae80>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.paragraph.Paragraph at 0xe3c7a90>"
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xe3c7080>"
+       "<docx.text.run.Run at 0xb20a390>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb944d08>"
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620288>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/plain": [
-       "<docx.text.run.Run at 0xb5b0390>"
+       "<docx.text.run.Run at 0xb20ae80>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
-     "ename": "PermissionError",
-     "evalue": "[Errno 13] Permission denied: '2019-01-14 papers.docx'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mPermissionError\u001b[0m                           Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-23-47938c15df20>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[0;32m      8\u001b[0m     \u001b[0madd_hyperlink\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mp\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;34m'{}'\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mrow\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;34m'link'\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;34m'{}'\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mrow\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;34m'source'\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      9\u001b[0m     \u001b[0mp\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0madd_run\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m')'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 10\u001b[1;33m \u001b[0mnewsdoc\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msave\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'{} papers.docx'\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0msearch_date\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;32m~\\AppData\\Local\\Continuum\\anaconda3-1\\lib\\site-packages\\docx\\document.py\u001b[0m in \u001b[0;36msave\u001b[1;34m(self, path_or_stream)\u001b[0m\n\u001b[0;32m    140\u001b[0m         \u001b[0ma\u001b[0m \u001b[0mfilesystem\u001b[0m \u001b[0mlocation\u001b[0m \u001b[1;33m(\u001b[0m\u001b[0ma\u001b[0m \u001b[0mstring\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;32mor\u001b[0m \u001b[0ma\u001b[0m \u001b[0mfile\u001b[0m\u001b[1;33m-\u001b[0m\u001b[0mlike\u001b[0m \u001b[0mobject\u001b[0m\u001b[1;33m.\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    141\u001b[0m         \"\"\"\n\u001b[1;32m--> 142\u001b[1;33m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_part\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msave\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mpath_or_stream\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    143\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    144\u001b[0m     \u001b[1;33m@\u001b[0m\u001b[0mproperty\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\AppData\\Local\\Continuum\\anaconda3-1\\lib\\site-packages\\docx\\parts\\document.py\u001b[0m in \u001b[0;36msave\u001b[1;34m(self, path_or_stream)\u001b[0m\n\u001b[0;32m    128\u001b[0m         \u001b[0ma\u001b[0m \u001b[0mfilesystem\u001b[0m \u001b[0mlocation\u001b[0m \u001b[1;33m(\u001b[0m\u001b[0ma\u001b[0m \u001b[0mstring\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;32mor\u001b[0m \u001b[0ma\u001b[0m \u001b[0mfile\u001b[0m\u001b[1;33m-\u001b[0m\u001b[0mlike\u001b[0m \u001b[0mobject\u001b[0m\u001b[1;33m.\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    129\u001b[0m         \"\"\"\n\u001b[1;32m--> 130\u001b[1;33m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpackage\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msave\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mpath_or_stream\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    131\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    132\u001b[0m     \u001b[1;33m@\u001b[0m\u001b[0mproperty\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\AppData\\Local\\Continuum\\anaconda3-1\\lib\\site-packages\\docx\\opc\\package.py\u001b[0m in \u001b[0;36msave\u001b[1;34m(self, pkg_file)\u001b[0m\n\u001b[0;32m    158\u001b[0m         \u001b[1;32mfor\u001b[0m \u001b[0mpart\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mparts\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    159\u001b[0m             \u001b[0mpart\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mbefore_marshal\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 160\u001b[1;33m         \u001b[0mPackageWriter\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mpkg_file\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mrels\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mparts\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    161\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    162\u001b[0m     \u001b[1;33m@\u001b[0m\u001b[0mproperty\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\AppData\\Local\\Continuum\\anaconda3-1\\lib\\site-packages\\docx\\opc\\pkgwriter.py\u001b[0m in \u001b[0;36mwrite\u001b[1;34m(pkg_file, pkg_rels, parts)\u001b[0m\n\u001b[0;32m     30\u001b[0m         \u001b[0mcontent\u001b[0m \u001b[0mtypes\u001b[0m \u001b[0mof\u001b[0m \u001b[0mthe\u001b[0m \u001b[0mparts\u001b[0m\u001b[1;33m.\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     31\u001b[0m         \"\"\"\n\u001b[1;32m---> 32\u001b[1;33m         \u001b[0mphys_writer\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mPhysPkgWriter\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mpkg_file\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     33\u001b[0m         \u001b[0mPackageWriter\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_write_content_types_stream\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mphys_writer\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mparts\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     34\u001b[0m         \u001b[0mPackageWriter\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_write_pkg_rels\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mphys_writer\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mpkg_rels\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\AppData\\Local\\Continuum\\anaconda3-1\\lib\\site-packages\\docx\\opc\\phys_pkg.py\u001b[0m in \u001b[0;36m__init__\u001b[1;34m(self, pkg_file)\u001b[0m\n\u001b[0;32m    139\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0m__init__\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mpkg_file\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    140\u001b[0m         \u001b[0msuper\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0m_ZipPkgWriter\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 141\u001b[1;33m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_zipf\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mZipFile\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mpkg_file\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;34m'w'\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcompression\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mZIP_DEFLATED\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    142\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    143\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mclose\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\AppData\\Local\\Continuum\\anaconda3-1\\lib\\zipfile.py\u001b[0m in \u001b[0;36m__init__\u001b[1;34m(self, file, mode, compression, allowZip64, compresslevel)\u001b[0m\n\u001b[0;32m   1180\u001b[0m             \u001b[1;32mwhile\u001b[0m \u001b[1;32mTrue\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1181\u001b[0m                 \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1182\u001b[1;33m                     \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfp\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mio\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mfile\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mfilemode\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   1183\u001b[0m                 \u001b[1;32mexcept\u001b[0m \u001b[0mOSError\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1184\u001b[0m                     \u001b[1;32mif\u001b[0m \u001b[0mfilemode\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mmodeDict\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mPermissionError\u001b[0m: [Errno 13] Permission denied: '2019-01-14 papers.docx'"
-     ]
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a908>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620288>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20af98>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620288>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a940>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620288>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a828>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620288>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a390>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb0b2048>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a908>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb0b2048>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xc48a2e8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20af98>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xb0b28c8>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.paragraph.Paragraph at 0xb1a4208>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20a940>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Element {http://schemas.openxmlformats.org/wordprocessingml/2006/main}hyperlink at 0xc620d08>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<docx.text.run.Run at 0xb20ae80>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -2896,7 +3720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-12-19T15:08:25.392357Z",


### PR DESCRIPTION
Paypuh_scraypuh can now

- Load more articles on the main feed page
- Reveal hidden titles, summaries, and dates by clicking css elements on the page.
- Handle sources that have multiple feeds (i.e., Transportation Research is now one source with 6 urls associate with Parts A-F)

I renamed the function to css_scraypuh since it's used to scrape pages with css elements that hide certain content.  It works for journal articles and non-journal articles.

I also added Detroit News and Transport Policy to the scraper.